### PR TITLE
Fix right-to-left implementation, add tests

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -68,7 +68,7 @@ class Browser:
                     x0, y0, x1, y1, fill="blue", tags="scrollbar"
                 )
 
-    def draw(self, font=None) -> None:
+    def draw(self, font=None):
         self.canvas.delete("text")
         for x, y, c, font in self.display_list:
             if y > self.scroll + self.screen_height:

--- a/layout.py
+++ b/layout.py
@@ -51,15 +51,12 @@ class Layout:
             self.flush()
 
         self.line.append((self.cursor_x, word, font))
-        if self.rtl:
-            self.cursor_x -= w + font.measure(" ")
-        else:
-            self.cursor_x += w + font.measure(" ")
+        self.cursor_x += w + font.measure(" ")
 
-        # # Increase cursor_y if the character is a newline
-        # if word == "\n":
-        #     self.cursor_y += VSTEP
-        #     self.cursor_x = HSTEP
+        # Increase cursor_y if the character is a newline
+        if word == "\n":
+            self.cursor_y += VSTEP
+            self.cursor_x = HSTEP
 
     def flush(self):
         if not self.line:
@@ -70,26 +67,26 @@ class Layout:
         max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
 
+        if self.rtl:
+            offset = self.width - (HSTEP * 2) - self.cursor_x
+
         # Add words to display_list
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
+            if self.rtl:
+                x += offset
             self.display_list.append((x, y, word, font))
 
         # Update cursor_x and cursor_y
         # cursor_y moves below baseline to account for deepest character
         max_descent = max([metric["descent"] for metric in metrics])
         self.cursor_y = baseline + 1.25 * max_descent
-        if self.rtl:
-            self.cursor_x = self.width - HSTEP
-        else:
-            self.cursor_x = HSTEP
+        self.cursor_x = HSTEP
         self.line = []
 
-    def __init__(self, tokens: "list[str]", width: int = WIDTH, rtl: bool = False):
+    def __init__(self, tokens, width: int = WIDTH, rtl: bool = False):
         self.rtl = rtl
         self.cursor_x, self.cursor_y = HSTEP, VSTEP
-        if self.rtl:
-            self.cursor_x = width - HSTEP
         self.weight, self.style = "normal", "roman"
         self.display_list = []
 
@@ -104,37 +101,8 @@ class Layout:
 
         self.flush()
 
-    # Exercise 2.7
-    def layout_rtl(self, text: str, width: int = WIDTH):
-        cursor_x = width - HSTEP
-        cursor_y = VSTEP
-        font = tkinter.font.Font(family="Times", size=16)
 
-        # Keep track of current line in list, and when you reach
-        # a new line, append existing list to display_list, but lay out in reverse
-        line = []
-        for c in text:
-            # If cursor_x is still within the same line, keep
-            # adding to line array
-            if cursor_x >= HSTEP and c != "\n":
-                line.append(c)
-                cursor_x -= HSTEP
-            else:
-                # If cursor_x is now at the end of the line, lay out line list,
-                # starting from the rightmost edge
-                cursor_x = width - HSTEP
-                line.reverse()
-                for l in line:
-                    self.display_list.append((cursor_x, cursor_y, l, font))
-                    cursor_x -= HSTEP
-                cursor_y += VSTEP
-
-                # Reset cursor_x so the next iteration begins a new line
-                cursor_x = width - HSTEP
-                line = []
-
-
-def lex(body: str) -> "list[str]":
+def lex(body: str) -> list:
     buffer = ""
     out = []
     in_tag = False

--- a/test_browser.py
+++ b/test_browser.py
@@ -1,0 +1,15 @@
+from browser import Browser
+from url import URL
+from test_utils import socket
+
+
+class TestBrowser:
+    def test_browser_load(self):
+        _ = socket.patch().start()
+        url = "http://test.test/example1"
+        socket.respond(
+            url, b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"Body text"
+        )
+        browser = Browser()
+        browser.load(URL(url))
+        assert browser.display_list is not None

--- a/test_layout.py
+++ b/test_layout.py
@@ -1,0 +1,20 @@
+from layout import Layout, Text, Tag
+import test_utils
+from constants import HSTEP
+
+
+class TestLayout:
+    def test_rtl(self):
+        text = [Text("Test1"), Text("test2")]
+        layout = Layout(text, rtl=True)
+        assert len(layout.display_list) == 2
+        word1 = layout.display_list[0]
+
+        # x coordinate of first word should be offset
+        assert word1[0] > HSTEP
+        assert word1[2] == "Test1"
+
+        word2 = layout.display_list[1]
+        # Word 2 should lay out after word 1
+        assert word2[0] > word1[0]
+        assert word2[2] == "test2"

--- a/test_url.py
+++ b/test_url.py
@@ -1,6 +1,6 @@
 from url import URL
-
-from unittest import mock
+from test_utils import socket, ssl
+from unittest.mock import mock_open, patch
 
 
 class TestURL:
@@ -26,112 +26,27 @@ class TestURL:
         url = URL("file://test.txt")
         assert url.scheme == "file"
 
-
-class socket:
-    URLs = {}
-    Requests = {}
-
-    def __init__(self, *args, **kwargs):
-        self.request = b""
-        self.connected = False
-
-    def connect(self, host_port):
-        self.scheme = "http"
-        self.host, self.port = host_port
-        self.connected = True
-
-    def send(self, text):
-        self.request += text
-        self.method, self.path, _ = self.request.decode("latin1").split(" ", 2)
-
-        if self.method == "POST":
-            beginning, self.body = self.request.decode("latin1").split("\r\n\r\n")
-            headers = [item.split(": ") for item in beginning.split("\r\n")[1:]]
-            assert any(name.casefold() == "content-length" for name, value in headers)
-            assert all(
-                int(value) == len(self.body)
-                for name, value in headers
-                if name.casefold() == "content-length"
-            )
-
-    def makefile(self, mode, encoding=None, newline=None):
-        assert self.connected and self.host and self.port
-        if self.port == 80 and self.scheme == "http":
-            url = self.scheme + "://" + self.host + self.path
-        elif self.port == 443 and self.scheme == "https":
-            url = self.scheme + "://" + self.host + self.path
-        else:
-            url = self.scheme + "://" + self.host + ":" + str(self.port) + self.path
-        self.Requests.setdefault(url, []).append(self.request)
-        assert (
-            self.method == self.URLs[url][0]
-        ), f"Made a {self.method} request to a {self.URLs[url][0]} URL"
-        output = self.URLs[url][1]
-        if self.URLs[url][2]:
-            assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
-        stream = io.BytesIO(output)
-        if encoding:
-            stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
-            stream.mode = mode
-        else:
-            assert mode == "b", "If no file encoding is passed, must pass 'b' mode"
-
-        return stream
-
-    def close(self):
-        self.connected = False
-
-    @classmethod
-    def patch(cls):
-        return mock.patch("socket.socket", wraps=cls)
-
-    @classmethod
-    def respond(cls, url, response, method="GET", body=None):
-        cls.URLs[url] = [method, response, body]
-
-    @classmethod
-    def respond_ok(cls, url, response, method="GET", body=None):
-        response = ("HTTP/1.0 200 OK\r\n\r\n" + response).encode("utf8")
-        cls.URLs[url] = [method, response, body]
-
-    @classmethod
-    def serve(cls, html):
-        html = html.encode("utf8") if isinstance(html, str) else html
-        response = b"HTTP/1.0 200 OK\r\n"
-        response += b"Content-Type: text/html\r\n"
-        response += b"Content-Length: " + str(len(html)).encode("ascii") + b"\r\n"
-        response += b"\r\n" + html
-        prefix = "http://test/"
-        url = next(
-            prefix + str(i) for i in range(1000) if prefix + str(i) not in cls.URLs
+    def test_request_http(self):
+        _ = socket.patch().start()
+        url = "http://test.test/example1"
+        socket.respond(
+            url, b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"Body text"
         )
-        cls.respond(url, response)
-        return url
+        body = URL(url).request()
+        assert body == "Body text"
 
-    @classmethod
-    def made_request(cls, url):
-        return url in cls.Requests
+    def test_request_https(self):
+        _ = socket.patch().start()
+        _ = ssl.patch().start()
+        url = "https://test.test/example1"
+        socket.respond(
+            url, b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"Body text"
+        )
+        body = URL(url).request()
+        assert body == "Body text"
 
-    @classmethod
-    def last_request(cls, url):
-        return cls.Requests[url][-1]
-
-    @classmethod
-    def clear_history(cls):
-        cls.Requests = {}
-
-
-class ssl:
-    def wrap_socket(self, s, server_hostname):
-        assert s.host == server_hostname
-        s.scheme = "https"
-        return s
-
-    @classmethod
-    def patch(cls):
-        return mock.patch("ssl.create_default_context", wraps=cls)
-
-
-class SilentTk:
-    def bind(self, event, callback):
-        pass
+    def test_request_file(self):
+        with patch("builtins.open", mock_open(read_data="testdata")):
+            url = "file://test.txt"
+            body = URL(url).request()
+            assert body == "testdata"

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import io
+import tkinter.font
 
 
 class socket:
@@ -111,3 +112,40 @@ class ssl:
 class SilentTk:
     def bind(self, event, callback):
         pass
+
+
+class TkFont:
+    def __init__(self, size=None, weight=None, slant=None, style=None):
+        self.size = size
+        self.weight = weight
+        self.slant = slant
+        self.style = style
+
+    def measure(self, word):
+        return self.size * len(word)
+
+    def metrics(self, name=None):
+        all = {
+            "ascent": self.size * 0.75,
+            "descent": self.size * 0.25,
+            "linespace": self.size,
+        }
+        if name:
+            return all[name]
+        return all
+
+    def __repr__(self):
+        return "Font size={} weight={} slant={} style={}".format(
+            self.size, self.weight, self.slant, self.style
+        )
+
+
+tkinter.font.Font = TkFont
+
+
+class TkLabel:
+    def __init__(self, font):
+        pass
+
+
+tkinter.Label = TkLabel

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,113 @@
+from unittest import mock
+import io
+
+
+class socket:
+    URLs = {}
+    Requests = {}
+
+    def __init__(self, *args, **kwargs):
+        self.request = b""
+        self.connected = False
+
+    def connect(self, host_port):
+        self.scheme = "http"
+        self.host, self.port = host_port
+        self.connected = True
+
+    def send(self, text):
+        self.request += text
+        self.method, self.path, _ = self.request.decode("latin1").split(" ", 2)
+
+        if self.method == "POST":
+            beginning, self.body = self.request.decode("latin1").split("\r\n\r\n")
+            headers = [item.split(": ") for item in beginning.split("\r\n")[1:]]
+            assert any(name.casefold() == "content-length" for name, value in headers)
+            assert all(
+                int(value) == len(self.body)
+                for name, value in headers
+                if name.casefold() == "content-length"
+            )
+
+    def makefile(self, mode, encoding=None, newline=None):
+        assert self.connected and self.host and self.port
+        if self.port == 80 and self.scheme == "http":
+            url = self.scheme + "://" + self.host + self.path
+        elif self.port == 443 and self.scheme == "https":
+            url = self.scheme + "://" + self.host + self.path
+        else:
+            url = self.scheme + "://" + self.host + ":" + str(self.port) + self.path
+        self.Requests.setdefault(url, []).append(self.request)
+        assert (
+            self.method == self.URLs[url][0]
+        ), f"Made a {self.method} request to a {self.URLs[url][0]} URL"
+        output = self.URLs[url][1]
+        if self.URLs[url][2]:
+            assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
+        stream = io.BytesIO(output)
+        if encoding:
+            stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
+            stream.mode = mode
+        else:
+            assert mode == "b", "If no file encoding is passed, must pass 'b' mode"
+
+        return stream
+
+    def close(self):
+        self.connected = False
+
+    @classmethod
+    def patch(cls):
+        return mock.patch("socket.socket", wraps=cls)
+
+    @classmethod
+    def respond(cls, url, response, method="GET", body=None):
+        cls.URLs[url] = [method, response, body]
+        print("URLs in test socket", cls.URLs)
+
+    @classmethod
+    def respond_ok(cls, url, response, method="GET", body=None):
+        response = ("HTTP/1.0 200 OK\r\n\r\n" + response).encode("utf8")
+        cls.URLs[url] = [method, response, body]
+
+    @classmethod
+    def serve(cls, html):
+        html = html.encode("utf8") if isinstance(html, str) else html
+        response = b"HTTP/1.0 200 OK\r\n"
+        response += b"Content-Type: text/html\r\n"
+        response += b"Content-Length: " + str(len(html)).encode("ascii") + b"\r\n"
+        response += b"\r\n" + html
+        prefix = "http://test/"
+        url = next(
+            prefix + str(i) for i in range(1000) if prefix + str(i) not in cls.URLs
+        )
+        cls.respond(url, response)
+        return url
+
+    @classmethod
+    def made_request(cls, url):
+        return url in cls.Requests
+
+    @classmethod
+    def last_request(cls, url):
+        return cls.Requests[url][-1]
+
+    @classmethod
+    def clear_history(cls):
+        cls.Requests = {}
+
+
+class ssl:
+    def wrap_socket(self, s, server_hostname):
+        assert s.host == server_hostname
+        s.scheme = "https"
+        return s
+
+    @classmethod
+    def patch(cls):
+        return mock.patch("ssl.create_default_context", wraps=cls)
+
+
+class SilentTk:
+    def bind(self, event, callback):
+        pass


### PR DESCRIPTION
* Properly mock out `socket` and some `tkinter` calls, copied from [test.py](https://github.com/browserengineering/book/blob/main/src/test.py) in textbook, and use these in `test_browser.py`, `test_layout.py`, and `test_url.py`
* Update RTL setting (exercise 2.7) to calculate an offset in the `flush` method and use it to shift words before appending to `display_list`, rather than reversing the word list