### PR TITLE
3.1: add center alignment

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -34,7 +34,9 @@ class Browser:
         if not body:
             return
         self.text = lex(body)
-        self.display_list = Layout(self.text, rtl=self.rtl).display_list
+        self.display_list = Layout(
+            tokens=self.text, width=self.screen_width, rtl=self.rtl
+        ).display_list
         self.draw_scrollbar()
         self.draw()
 
@@ -118,7 +120,9 @@ class Browser:
             return
         self.screen_height = e.height
         self.screen_width = e.width
-        self.display_list = Layout(self.text, self.screen_width, self.rtl).display_list
+        self.display_list = Layout(
+            tokens=self.text, width=self.screen_width, rtl=self.rtl
+        ).display_list
         self.draw()
         self.draw_scrollbar()
 

--- a/constants.py
+++ b/constants.py
@@ -2,6 +2,6 @@ SCROLLBAR_WIDTH = 20
 HSTEP, VSTEP = 13, 18
 WIDTH, HEIGHT = 800, 600
 SCROLL_STEP = 100
-TEST_FILE = "/Users/margotkriete/Desktop/test.txt"
+TEST_FILE = "/Users/margotkriete/Desktop/test.html"
 SCROLLBAR_WIDTH = 20
 PORTS = {"http": 80, "https": 443}

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 SCROLLBAR_WIDTH = 20
 HSTEP, VSTEP = 13, 18
 WIDTH, HEIGHT = 800, 600
@@ -5,3 +7,8 @@ SCROLL_STEP = 100
 TEST_FILE = "/Users/margotkriete/Desktop/test.html"
 SCROLLBAR_WIDTH = 20
 PORTS = {"http": 80, "https": 443}
+
+
+class Alignment(Enum):
+    RIGHT = 1
+    CENTER = 2

--- a/layout.py
+++ b/layout.py
@@ -49,7 +49,9 @@ class Layout:
                     self.flush()
                     self.cursor_y += VSTEP
                 case 'h1 class="title"':
-                    print("found h1 tag")
+                    self.parent_tag = tok.tag
+                case "/h1":
+                    self.parent_tag = None
 
     def word(self, word) -> None:
         font = get_font(self.size, self.weight, self.style)
@@ -76,15 +78,19 @@ class Layout:
         metrics = [item.font.metrics() for item in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
+        offset: int = 0
 
         if self.rtl:
             offset = self.width - (HSTEP * 2) - self.cursor_x
 
+        if self.parent_tag == 'h1 class="title"':
+            offset = int((self.width - self.line[-1].x) / 2)
+
+        print("self.line", self.line)
         # Add words to display_list
         for item in self.line:
             y = baseline - item.font.metrics("ascent")
-            if self.rtl:
-                item.x += offset
+            item.x += offset
             self.display_list.append(DisplayListItem(item.x, y, item.text, item.font))
 
         # Update cursor_x and cursor_y
@@ -104,6 +110,7 @@ class Layout:
         self.line: list[LineItem] = []
         self.width: int = width
         self.size: int = 12
+        self.alignment = "none"
 
         for tok in tokens:
             self.token(tok)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,6 +1,6 @@
 import test_utils
-from constants import HSTEP
-from layout import Layout, Text
+from constants import HSTEP, SCROLLBAR_WIDTH
+from layout import Layout, Text, Tag
 
 
 class TestLayout:
@@ -18,3 +18,20 @@ class TestLayout:
         # Word 2 should lay out after word 1
         assert word2.x > word1.x
         assert word2.text == "test2"
+
+    def test_h1_center_align(self):
+        text = [
+            Tag('h1 class="title"'),
+            Text("Test1"),
+            Text("test2"),
+            Tag("/h1"),
+            Text("test3"),
+        ]
+        layout = Layout(text)
+        assert len(layout.display_list) == 3
+        # First word is the title, ensure it's centered
+        word1 = layout.display_list[0]
+        assert word1.x > HSTEP
+        # Word 3 is outside of h1 tag so, should be right-aligned
+        word3 = layout.display_list[2]
+        assert word3.x == HSTEP

--- a/typedclasses.py
+++ b/typedclasses.py
@@ -2,6 +2,16 @@ import tkinter.font
 from dataclasses import dataclass
 
 
+class Text:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class Tag:
+    def __init__(self, tag: str):
+        self.tag = tag
+
+
 @dataclass
 class ScrollbarCoordinate:
     x0: int
@@ -23,3 +33,4 @@ class LineItem:
     x: int
     text: str
     font: tkinter.font.Font
+    parent: Tag

--- a/typedclasses.py
+++ b/typedclasses.py
@@ -33,4 +33,3 @@ class LineItem:
     x: int
     text: str
     font: tkinter.font.Font
-    parent: Tag

--- a/typedclasses.py
+++ b/typedclasses.py
@@ -16,3 +16,10 @@ class DisplayListItem:
     y: int
     text: str
     font: tkinter.font.Font
+
+
+@dataclass
+class LineItem:
+    x: int
+    text: str
+    font: tkinter.font.Font

--- a/url.py
+++ b/url.py
@@ -57,7 +57,7 @@ class URL:
         return self.data
 
     # Exercise 2.6
-    def _request_about_blank(self) -> str:
+    def _request_about_blank(self) -> None:
         return None
 
     def _request_http(self) -> str:


### PR DESCRIPTION
* [3.1] Implement `h1` centering by adding an offset of `width - line length` (line length computed from the line's final `x` coordinate) when detected in the `token` step. Applies `alignment` globally and calls `.flush()` when `</h1`> is detected to reset the `line` buffer
* Fix a few type hints
* Also clean up `title` tag showing within body