### PR TITLE
Exercise 1.5: Implement view_source scheme

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -25,6 +25,7 @@ class Browser:
         self.screen_height = HEIGHT
         self.screen_width = WIDTH
         self.rtl = rtl
+        self.view_source = False
 
     def _get_page_height(self) -> int:
         return self.display_list[-1].y
@@ -33,12 +34,13 @@ class Browser:
         body = url.request()
         if not body:
             return
-        self.text = lex(body)
+        self.view_source = url.view_source
+        self.text = lex(body, view_source=url.view_source)
         self.display_list = Layout(
             tokens=self.text, width=self.screen_width, rtl=self.rtl
         ).display_list
-        self.draw_scrollbar()
         self.draw()
+        self.draw_scrollbar()
 
     # Exercise 2.4
     def get_scrollbar_coordinates(self) -> ScrollbarCoordinate:
@@ -76,7 +78,7 @@ class Browser:
                 tags="scrollbar",
             )
 
-    def draw(self, font=None):
+    def draw(self):
         self.canvas.delete("text")
         for item in self.display_list:
             if item.y > self.scroll + self.screen_height:

--- a/layout.py
+++ b/layout.py
@@ -93,7 +93,10 @@ class Layout:
         self.line = []
 
     def __init__(
-        self, tokens: list[Tag | Text], width: int = WIDTH, rtl: bool = False
+        self,
+        tokens: list[Tag | Text],
+        width: int = WIDTH,
+        rtl: bool = False,
     ) -> None:
         self.rtl: bool = rtl
         self.cursor_x, self.cursor_y = HSTEP, VSTEP
@@ -110,7 +113,8 @@ class Layout:
         self.flush()
 
 
-def lex(body: str) -> list[Tag | Text]:
+# Convert raw response body to a list of parsed Tags and Text
+def lex(body: str, view_source: bool = False) -> list[Tag | Text]:
     buffer = ""
     out: list[Tag | Text] = []
     in_tag = False
@@ -120,6 +124,12 @@ def lex(body: str) -> list[Tag | Text]:
     if title:
         title_text = title.group(1)
     body = body.replace(title_text, "")
+    body = body.replace("&gt;", ">")
+    body = body.replace("&lt;", "<")
+
+    if view_source:
+        out.append(Text(body))
+        return out
 
     for c in body:
         if c == "<":

--- a/test_utils.py
+++ b/test_utils.py
@@ -64,7 +64,6 @@ class socket:
     @classmethod
     def respond(cls, url, response, method="GET", body=None):
         cls.URLs[url] = [method, response, body]
-        print("URLs in test socket", cls.URLs)
 
     @classmethod
     def respond_ok(cls, url, response, method="GET", body=None):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -102,3 +102,16 @@ class TestBrowser:
         assert coordinates.y0 == 0
         assert coordinates.x1 == 1200
         assert coordinates.y1 == 652
+
+    def test_browser_view_source_renders_tags(self):
+        socket.patch().start()
+        socket.respond("http://example.org/", mock_http_response(b"<b>bodytext</b>"))
+        browser = Browser()
+        browser.load(URL("view_source:http://example.org"))
+        assert len(browser.display_list) == 1
+        assert browser.display_list[0].text == "<b>bodytext</b>"
+
+    def test_browser_http_does_not_render_tag(self, mock_socket):
+        browser = mock_socket(response_body_text=b"<b>bodytext</b>")
+        assert len(browser.display_list) == 1
+        assert browser.display_list[0].text == "bodytext"

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -57,3 +57,14 @@ class TestURL:
         url = "about:blank"
         body = URL(url).request()
         assert body is None
+
+    def test_view_source_parses_http_content(self):
+        socket.patch().start()
+        ssl.patch().start()
+        url = "view_source:https://test.test/example1"
+        socket.respond(
+            url,
+            b"HTTP/1.0 200 OK\r\n" + b"Header1: Value1\r\n\r\n" + b"Body text",
+        )
+        body = URL(url).request()
+        assert body == "Body text"

--- a/url.py
+++ b/url.py
@@ -7,8 +7,13 @@ from constants import PORTS
 class URL:
 
     def __init__(self, url: str) -> None:
+        self.view_source: bool = False
         try:
-            if url.startswith("data"):
+            if url.startswith("view_source"):
+                view_source, full_url = url.split(":", 1)
+                self.scheme, url = full_url.split("://", 1)
+                self.view_source = view_source == "view_source"
+            elif url.startswith("data"):
                 self.scheme, url = url.split(":", 1)
             else:
                 self.scheme, url = url.split("://", 1)
@@ -37,7 +42,7 @@ class URL:
         return req
 
     def request(self):
-        if self.scheme in ["http", "https"]:
+        if self.scheme in ["http", "https", "view_source"]:
             return self._request_http()
 
         if self.scheme == "data":


### PR DESCRIPTION
* Implement exercise 1.5 to support requests to `view_source:http(s)://url>`
* Save `view_source` on URL objects and pass to `lex` method, which aggregates `Text` and `Tags` on a string. When `view_source` URLs are requested, this PR parses the entire body, including tags, as if it's a single string (so a single `Text` object). The `draw()` method is unchanged