### PR TITLE
Exercise 3.4, implement abbr tag

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -12,6 +12,7 @@ class Layout:
     cursor_x: int
     line: list
     alignment: Enum
+    abbr: bool
 
     def token(self, tok: Text | Tag) -> None:
         if isinstance(tok, Text):
@@ -45,9 +46,19 @@ class Layout:
                 case "/h1":
                     self.flush()
                     self.alignment = Alignment.RIGHT
+                case "abbr":
+                    self.abbr = True
+                case "/abbr":
+                    self.abbr = False
 
-    def word(self, word) -> None:
-        font = get_font(self.size, self.weight, self.style)
+    def word(self, word: str) -> None:
+        if self.abbr:
+            for char in word:
+                if char.islower() and char.isalpha():
+                    font = get_font(self.size - 2, "bold", self.style)
+                    word = word.replace(char, char.upper())
+        else:
+            font = get_font(self.size, self.weight, self.style)
         w = font.measure(word)
 
         # Wrap text once we reach the edge of the screen
@@ -106,6 +117,7 @@ class Layout:
         self.width: int = width
         self.size: int = 12
         self.alignment: Enum = Alignment.RIGHT
+        self.abbr: bool = False
 
         for tok in tokens:
             self.token(tok)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -35,3 +35,12 @@ class TestLayout:
         # Word 3 is outside of h1 tag so, should be right-aligned
         word3 = layout.display_list[2]
         assert word3.x == HSTEP
+
+    def test_abbr_tag(self):
+        text = [Tag("abbr"), Text("json"), Tag("/abbr")]
+        layout = Layout(text)
+        assert len(layout.display_list) == 1
+        word1 = layout.display_list[0]
+        assert word1.text == "JSON"
+        assert word1.font.size == 10
+        assert word1.font.weight == "bold"


### PR DESCRIPTION
* Implements exercise 3.4 to support `<abbr`> tags: lowercase letters within `<abbr>` are small, capitalized, and bold, and other characters should be drawn in normal font
* Update `word` to check for `abbr` state and modify lowercase characters
* This PR does not properly measure words with mixed lowercase and uppercase letters; to do so, we can append `LineItem` while we loop through `word`