### PR TITLE
Implement chapter 4: document tree construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-This project is a Python implementation of the [Web Browser Engineering](http://browser.engineering) course. The program builds a basic, and currently very incomplete, web browser.
+This project is a Python implementation of the [Web Browser Engineering](http://browser.engineering) course. The program builds and launches a basic, and currently very incomplete, web browser.
 
 ### Requirements
 
 - TODO: add `requirements.txt` file
 - Python 3.10+
+- `pytest`
 
 ### Run browser
 
@@ -19,6 +20,12 @@ To request a file:
 $ python3 browser.py <FILENAME>
 ```
 
+To view a URL's source code:
+
+```
+$ python3 browser.py view-source:<URL>
+```
+
 ### Run tests
 
 Ensure you have `pytest` installed.
@@ -29,8 +36,8 @@ To run all tests:
 $ python3 -m pytest
 ```
 
-Add `test_browser.py`, `test_url.py`, or `test_layout.py` to run individual test files.
+Test cases are in the `tests` directory. Specify these files to run individual test cases.
 
 ```
-$ python3 -m pytest test_browser.py
+$ python3 -m pytest tests/test_browser.py
 ```

--- a/browser.py
+++ b/browser.py
@@ -35,8 +35,9 @@ class Browser:
         body = url.request()
         if not body:
             return
-        self.view_source = url.view_source
-        self.nodes: Element | Text = HTMLParser(body).parse()
+        self.nodes: Element | Text = HTMLParser(
+            body, view_source=url.view_source
+        ).parse()
         self.display_list = Layout(
             tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list
@@ -105,19 +106,19 @@ class Browser:
     def scrollup(self, e) -> None:
         if self.scroll >= SCROLL_STEP:
             self.scroll -= SCROLL_STEP
-        self.draw()
+            self.draw()
 
     # Exercise 2.2
     def mousescroll(self, e) -> None:
-        updated_scroll = self.scroll - e.delta + self.screen_height
-        if (updated_scroll < self._get_page_height()) and (self.scroll - e.delta > 0):
+        scroll_change = self.scroll - e.delta
+        if (scroll_change + self.screen_height < self._get_page_height()) and (
+            scroll_change > 0
+        ):
             self.scroll -= e.delta
             self.draw()
 
     # Exercise 2.3
     def resize(self, e: tkinter.Event) -> None:
-        if not hasattr(self, "text"):
-            return
         self.screen_height = e.height
         self.screen_width = e.width
         self.display_list = Layout(

--- a/browser.py
+++ b/browser.py
@@ -1,7 +1,7 @@
 import argparse
 import tkinter
 import tkinter.font
-from parser import HTMLParser, print_tree
+from parser import HTMLParser, Element, Text
 
 from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, VSTEP, WIDTH
 from layout import Layout
@@ -36,9 +36,9 @@ class Browser:
         if not body:
             return
         self.view_source = url.view_source
-        self.nodes = HTMLParser(body).parse()
+        self.nodes: Element | Text = HTMLParser(body).parse()
         self.display_list = Layout(
-            nodes=self.nodes, width=self.screen_width, rtl=self.rtl
+            tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list
         self.draw()
 
@@ -121,7 +121,7 @@ class Browser:
         self.screen_height = e.height
         self.screen_width = e.width
         self.display_list = Layout(
-            tokens=self.text, width=self.screen_width, rtl=self.rtl
+            tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list
         self.draw()
 

--- a/browser.py
+++ b/browser.py
@@ -1,9 +1,10 @@
 import argparse
 import tkinter
 import tkinter.font
+from parser import HTMLParser, print_tree
 
 from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, VSTEP, WIDTH
-from layout import Layout, lex
+from layout import Layout
 from typedclasses import ScrollbarCoordinate
 from url import URL
 
@@ -35,9 +36,9 @@ class Browser:
         if not body:
             return
         self.view_source = url.view_source
-        self.text = lex(body, view_source=url.view_source)
+        self.nodes = HTMLParser(body).parse()
         self.display_list = Layout(
-            tokens=self.text, width=self.screen_width, rtl=self.rtl
+            nodes=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list
         self.draw()
 

--- a/constants.py
+++ b/constants.py
@@ -12,3 +12,13 @@ PORTS = {"http": 80, "https": 443}
 class Alignment(Enum):
     RIGHT = 1
     CENTER = 2
+
+
+class Style(Enum):
+    ROMAN = "roman"
+    ITALIC = "italic"
+
+
+class Weight(Enum):
+    BOLD = "bold"
+    NORMAL = "normal"

--- a/layout.py
+++ b/layout.py
@@ -8,12 +8,6 @@ from parser import Text, Element
 from typing import Optional
 
 
-def replace_character_references(s: str) -> str:
-    s = s.replace("&lt;", "<")
-    s = s.replace("&gt;", ">")
-    return s
-
-
 class Layout:
     cursor_y: int
     cursor_x: int
@@ -145,7 +139,7 @@ class Layout:
             else:
                 for line in tree.text.split("\n"):
                     self.word(line)
-                    if not line:
+                    if line:
                         self.flush()
         else:
             self.open_tag(tree.tag, tree.attributes)

--- a/layout.py
+++ b/layout.py
@@ -140,7 +140,7 @@ class Layout:
 
     def __init__(
         self,
-        nodes: list[Element | Text],
+        tree: Element | Text,
         width: int = WIDTH,
         rtl: bool = False,
     ) -> None:
@@ -155,5 +155,5 @@ class Layout:
         self.abbr: bool = False
         self.in_pre: bool = False
         self.family = None
-        self.recurse(nodes)
+        self.recurse(tree)
         self.flush()

--- a/parser.py
+++ b/parser.py
@@ -1,55 +1,170 @@
 import re
+from typing import Optional, Tuple
 
 
 class Text:
     def __init__(self, text: str, parent):
         self.text: str = text
-        # Children here is never used? TODO: remove?
-        self.children: list[str] = []
+        self.children = []
         self.parent = parent
+
+    def __repr__(self):
+        return repr(self.text)
 
 
 class Element:
-    def __init__(self, tag: str, parent):
+    def __init__(self, tag: str, attributes: dict, parent):
         self.tag = tag
-        self.children: list[str] = []
+        self.children = []
         self.parent = parent
+        self.attributes = attributes
+
+    def __repr__(self):
+        return f"<{self.tag}>"
 
 
 class HTMLParser:
-    def __init__(self, body: str):
+    SELF_CLOSING_TAGS = [
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    ]
+    HEAD_TAGS = [
+        "base",
+        "basefont",
+        "bgsound",
+        "noscript",
+        "link",
+        "meta",
+        "title",
+        "style",
+        "script",
+    ]
+
+    def __init__(self, body: str, view_source: bool = False) -> None:
         self.body: str = body
         self.unfinished = []
+        self.view_source: bool = view_source
 
-    def parse(self, body: str, view_source: bool = False) -> list[Element | Text]:
-        buffer = ""
-        out: list[Element | Text] = []
+    def implicit_tags(self, tag: Optional[str] = None) -> None:
+        while True:
+            open_tags = [node.tag for node in self.unfinished]
+            if open_tags == [] and tag != "html":
+                self.add_tag("html")
+            elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
+                if tag in self.HEAD_TAGS:
+                    self.add_tag("head")
+                else:
+                    self.add_tag("body")
+            elif (
+                open_tags == ["html", "head"] and tag not in ["/head"] + self.HEAD_TAGS
+            ):
+                self.add_tag("/head")
+            else:
+                break
+
+    def get_attributes(self, text: str) -> Tuple[str, dict]:
+        parts: str = text.split()
+        tag = parts[0].casefold()
+        attributes: dict = {}
+        for attrpair in parts[1:]:
+            if "=" in attrpair:
+                key, value = attrpair.split("=", 1)
+                # fmt: off
+                if len(value) > 2 and value[0] in ["'", '\"']:
+                    value = value[1:-1]
+                attributes[key.casefold()] = value
+            else:
+                attributes[attrpair.casefold()] = ""
+        return tag, attributes
+
+    def parse(
+        self,
+    ) -> list[Element | Text]:
+        text: str = ""
         in_tag = False
 
-        title = re.search("<title>(.*)</title>", body)
+        title = re.search("<title>(.*)</title>", self.body)
         title_text = ""
         if title:
             title_text = title.group(1)
-        body = body.replace(title_text, "")
-        # body = body.replace("&gt;", ">")
-        # body = body.replace("&lt;", "<")
+        self.body = self.body.replace(title_text, "")
 
-        if view_source:
-            out.append(Text(body))
-            return out
+        if self.view_source:
+            self.add_text(text)
+            return self.finish()
 
-        for c in body:
+        for c in self.body:
             if c == "<":
                 in_tag = True  # word is in between < >
-                if buffer:
-                    out.append(Text(buffer))
-                buffer = ""
+                if text:
+                    self.add_text(text)
+                text = ""
             elif c == ">":
                 in_tag = False
-                out.append(Element(buffer))
-                buffer = ""
+                self.add_tag(text)
+                text = ""
             else:
-                buffer += c
-        if not in_tag and buffer:
-            out.append(Text(buffer))
-        return out
+                text += c
+        if not in_tag and text:
+            self.add_text(text)
+        return self.finish()
+
+    def add_text(self, text: str) -> None:
+        if text.isspace():
+            return
+        self.implicit_tags(None)
+        # Add text as a child of the last unfinished node
+        parent = self.unfinished[-1]
+        node: Text = Text(text, parent)
+        parent.children.append(node)
+
+    def add_tag(self, tag: str) -> None:
+        tag, attributes = self.get_attributes(tag)
+        if tag.startswith("!"):
+            return
+        self.implicit_tags(tag)
+        if tag.startswith("/"):
+            if len(self.unfinished) == 1:
+                return
+            # Close tags finish last unfinished node by adding
+            # it to the previous unfinished node
+            node = self.unfinished.pop()
+            parent = self.unfinished[-1]
+            parent.children.append(node)
+        elif tag in self.SELF_CLOSING_TAGS:
+            parent = self.unfinished[-1]
+            node: Element = Element(tag=tag, attributes=attributes, parent=parent)
+            parent.children.append(node)
+        else:
+            parent: Element | Text | None = (
+                self.unfinished[-1] if self.unfinished else None
+            )
+            node: Element = Element(tag=tag, attributes=attributes, parent=parent)
+            self.unfinished.append(node)
+
+    def finish(self) -> Element | Text:
+        if not self.unfinished:
+            self.implicit_tags(None)
+        while len(self.unfinished) > 1:
+            node: Element | Text = self.unfinished.pop()
+            parent = self.unfinished[-1]
+            parent.children.append(node)
+        return self.unfinished.pop()
+
+
+def print_tree(node, indent: int = 0):
+    print(" " * indent, node)
+    for child in node.children:
+        print_tree(child, indent + 1)

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,55 @@
+import re
+
+
+class Text:
+    def __init__(self, text: str, parent):
+        self.text: str = text
+        # Children here is never used? TODO: remove?
+        self.children: list[str] = []
+        self.parent = parent
+
+
+class Element:
+    def __init__(self, tag: str, parent):
+        self.tag = tag
+        self.children: list[str] = []
+        self.parent = parent
+
+
+class HTMLParser:
+    def __init__(self, body: str):
+        self.body: str = body
+        self.unfinished = []
+
+    def parse(self, body: str, view_source: bool = False) -> list[Element | Text]:
+        buffer = ""
+        out: list[Element | Text] = []
+        in_tag = False
+
+        title = re.search("<title>(.*)</title>", body)
+        title_text = ""
+        if title:
+            title_text = title.group(1)
+        body = body.replace(title_text, "")
+        # body = body.replace("&gt;", ">")
+        # body = body.replace("&lt;", "<")
+
+        if view_source:
+            out.append(Text(body))
+            return out
+
+        for c in body:
+            if c == "<":
+                in_tag = True  # word is in between < >
+                if buffer:
+                    out.append(Text(buffer))
+                buffer = ""
+            elif c == ">":
+                in_tag = False
+                out.append(Element(buffer))
+                buffer = ""
+            else:
+                buffer += c
+        if not in_tag and buffer:
+            out.append(Text(buffer))
+        return out

--- a/parser.py
+++ b/parser.py
@@ -57,6 +57,11 @@ class HTMLParser:
         "script",
     ]
 
+    def replace_character_references(self, s: str) -> str:
+        s = s.replace("&lt;", "<")
+        s = s.replace("&gt;", ">")
+        return s
+
     def __init__(self, body: str, view_source: bool = False) -> None:
         self.body: str = body
         self.unfinished: list[Element] = []
@@ -120,14 +125,17 @@ class HTMLParser:
                 text = ""
             else:
                 text += c
+
         if not in_tag and text:
             self.add_text(text)
         return self.finish()
 
     def add_text(self, text: str) -> None:
         if text.isspace():
-            return
+            if len(self.unfinished) and self.unfinished[-1].tag != "pre":
+                return
         self.implicit_tags(None)
+        text = self.replace_character_references(text)
         # Add text as a child of the last unfinished node
         parent: Element = self.unfinished[-1]
         node: Text = Text(text, parent)

--- a/parser.py
+++ b/parser.py
@@ -3,21 +3,26 @@ from typing import Optional, Tuple
 
 
 class Text:
-    def __init__(self, text: str, parent):
+    def __init__(self, text: str, parent: "Element"):
         self.text: str = text
         self.children: list[Element | Text] = []
-        self.parent = parent
+        self.parent: Element = parent
 
     def __repr__(self) -> str:
         return repr(self.text)
 
 
 class Element:
-    def __init__(self, tag: str, attributes: dict, parent: Optional["Element"] = None):
-        self.tag = tag
+    def __init__(
+        self,
+        tag: str,
+        attributes: Optional[dict] = None,
+        parent: Optional["Element"] = None,
+    ):
+        self.tag: str = tag
         self.children: list[Element | Text] = []
         self.parent: Optional[Element] = parent
-        self.attributes = attributes
+        self.attributes: Optional[dict] = attributes
 
     def __repr__(self) -> str:
         return f"<{self.tag}>"
@@ -100,7 +105,7 @@ class HTMLParser:
         self.body = self.body.replace(title_text, "")
 
         if self.view_source:
-            self.add_text(text)
+            self.add_text(self.body)
             return self.finish()
 
         for c in self.body:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -70,7 +70,6 @@ class TestBrowser:
         e.height = 400
         e.width = 600
         browser.resize(e)
-
         assert browser.screen_width == e.width
 
         # All x coordinates should be > HSTEP and < screen width

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,6 +1,7 @@
 import test_utils
-from constants import HSTEP, SCROLLBAR_WIDTH
-from layout import Layout, Text, Tag
+from constants import HSTEP
+from layout import Layout
+from parser import Text, Element
 
 
 class TestLayout:
@@ -21,10 +22,10 @@ class TestLayout:
 
     def test_h1_center_align(self):
         text = [
-            Tag('h1 class="title"'),
+            Element('h1 class="title"'),
             Text("Test1"),
             Text("test2"),
-            Tag("/h1"),
+            Element("/h1"),
             Text("test3"),
         ]
         layout = Layout(text)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -38,7 +38,7 @@ class TestLayout:
         assert word3.x == HSTEP
 
     def test_abbr_tag(self):
-        text = [Tag("abbr"), Text("json"), Tag("/abbr")]
+        text = [Element("abbr"), Text("json"), Element("/abbr")]
         layout = Layout(text)
         assert len(layout.display_list) == 1
         word1 = layout.display_list[0]

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,13 +1,13 @@
 import test_utils
 from constants import HSTEP
 from layout import Layout
-from parser import Text, Element
+from parser import Text, Element, HTMLParser
 
 
 class TestLayout:
     def test_rtl(self):
-        text = [Text("Test1"), Text("test2")]
-        layout = Layout(text, rtl=True)
+        tree = HTMLParser("<head><p>Test1 test2</p>").parse()
+        layout = Layout(tree, rtl=True)
         assert len(layout.display_list) == 2
         word1 = layout.display_list[0]
 
@@ -21,16 +21,10 @@ class TestLayout:
         assert word2.text == "test2"
 
     def test_h1_center_align(self):
-        text = [
-            Element('h1 class="title"'),
-            Text("Test1"),
-            Text("test2"),
-            Element("/h1"),
-            Text("test3"),
-        ]
-        layout = Layout(text)
+        tree = HTMLParser("<head><h1 class='title'>Test1 test2</h1>test3").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 3
-        # First word is the title, ensure it's centered
+        # Ensure title is centered
         word1 = layout.display_list[0]
         assert word1.x > HSTEP
         # Word 3 is outside of h1 tag so, should be right-aligned
@@ -38,8 +32,8 @@ class TestLayout:
         assert word3.x == HSTEP
 
     def test_abbr_tag(self):
-        text = [Element("abbr"), Text("json"), Element("/abbr")]
-        layout = Layout(text)
+        tree = HTMLParser("<head><abbr>json</abbr>").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 1
         word1 = layout.display_list[0]
         assert word1.text == "JSON"
@@ -47,12 +41,10 @@ class TestLayout:
         assert word1.font.weight == "bold"
 
     def test_soft_hyphen_breaks_long_line(self):
-        text = [
-            Text(
-                "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            )
-        ]
-        layout = Layout(text)
+        tree = HTMLParser(
+            "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ).parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 2
         assert (
             layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
@@ -63,18 +55,16 @@ class TestLayout:
         assert layout.display_list[0].y < layout.display_list[1].y
 
     def test_soft_hyphen_removes_hyphen_if_word_fits(self):
-        text = [Text("super­cali­fragi­list&shy;ic­expi­ali­docious")]
-        layout = Layout(text)
+        tree = HTMLParser("super­cali­fragi­list&shy;ic­expi­ali­docious").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
 
     def test_soft_hyphen_handles_multiple_hyphens(self):
-        text = [
-            Text(
-                "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&shy;bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            )
-        ]
-        layout = Layout(text)
+        tree = HTMLParser(
+            "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&shy;bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ).parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 3
         assert (
             layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
@@ -83,28 +73,32 @@ class TestLayout:
         assert layout.display_list[2].text == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     def test_pre_tag_uses_monospaced_font(self):
-        layout = Layout([Tag("pre"), Text("def get_font(self):"), Tag("/pre")])
+        tree = HTMLParser("<pre>def get_font(self):</pre>").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].font.family == "Courier New"
 
     def test_pre_tag_maintains_whitespace(self):
-        layout = Layout(
-            [Tag("pre"), Text("def get_font(self):               return"), Tag("/pre")]
-        )
+        tree = HTMLParser("<pre>def get_font(self):               return</pre").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].text == "def get_font(self):               return"
 
     def test_pre_tag_maintains_nested_tags(self):
-        layout = Layout(
-            [
-                Tag("pre"),
-                Text("def get_font(self):"),
-                Tag("b"),
-                Text("return"),
-                Tag("/b"),
-                Tag("/pre"),
-            ]
-        )
+        tree = HTMLParser("<pre>def get_font(self):<b>return</b></pre").parse()
+        layout = Layout(tree)
         assert len(layout.display_list) == 2
         assert layout.display_list[1].font.weight == "bold"
         assert layout.display_list[1].font.family == "Courier New"
+
+    def test_abbr_tag_respects_mixed_casing(self):
+        # This doesn't pass the specifications in the exercise, as it
+        # still bolds the uppercase letters in e.g. JsOn
+        tree = HTMLParser("<head><abbr>JsOn 123</abbr>").parse()
+        layout = Layout(tree)
+        assert len(layout.display_list) == 2
+        word1 = layout.display_list[0]
+        assert word1.text == "JSON"
+        word2 = layout.display_list[1]
+        assert word2.text == "123"
+        assert word2.font.weight == "normal"

--- a/typedclasses.py
+++ b/typedclasses.py
@@ -2,16 +2,6 @@ import tkinter.font
 from dataclasses import dataclass
 
 
-class Text:
-    def __init__(self, text: str):
-        self.text = text
-
-
-class Tag:
-    def __init__(self, tag: str):
-        self.tag = tag
-
-
 @dataclass
 class ScrollbarCoordinate:
     x0: int


### PR DESCRIPTION
This chapter does not introduce any cosmetic changes, but converts `Layout` to represent HTML elements as a tree of tags, instead of a list.

* Add a new class, `HTMLParser`, to convert raw HTML to a tree structure, with text leaf nodes using the `Text` class and all other nodes using the `Element` class
  * `parse()` identifies text and tags in the string body
  * Text nodes are added as children of the last "unfinished" node
  * Open tags are added as new unfinished nodes, and close tags finish the last unfinished node
  * To finish the parser, any unfinished nodes are popped and added as children
* Modify `Browser` to call `.parse()` to parse the tree, and pass this tree to `Layout`
* In `Layout`, split `token()` into `open_tag` and `close_tag`, which apply styling before and after, respectively, we recurse the tree. Leaf nodes (text) are treated as the base case
* Smaller changes: fix tests following refactor, use enums for styling constants, update README, attempt to fix `pre` tags by allowing whitespace nodes