### PR TITLE
Exercise 3.5, implement `pre` tag

### DIFF
--- a/font_cache.py
+++ b/font_cache.py
@@ -1,12 +1,17 @@
 import tkinter
+from typing import Optional
 
 FONTS = {}
 
 
-def get_font(size, weight, style) -> tkinter.font.Font:
-    key = (size, weight, style)
+def get_font(
+    size: int, weight: str, style: str, family: Optional[str] = None
+) -> tkinter.font.Font:
+    key: tuple = (size, weight, style, family)
     if key not in FONTS:
-        font = tkinter.font.Font(size=size, weight=weight, slant=style)
-        label = tkinter.Label(font=font)
+        font: tkinter.font.Font = tkinter.font.Font(
+            size=size, weight=weight, slant=style, family=family
+        )
+        label: tkinter.Label = tkinter.Label(font=font)
         FONTS[key] = (font, label)
     return FONTS[key][0]

--- a/layout.py
+++ b/layout.py
@@ -7,17 +7,30 @@ from font_cache import get_font
 from typedclasses import DisplayListItem, LineItem, Tag, Text
 
 
+def replace_character_references(s: str) -> str:
+    s = s.replace("&lt;", "<")
+    s = s.replace("&gt;", ">")
+    return s
+
+
 class Layout:
     cursor_y: int
     cursor_x: int
     line: list
     alignment: Enum
     abbr: bool
+    in_pre: bool
 
     def token(self, tok: Text | Tag) -> None:
         if isinstance(tok, Text):
-            for word in tok.text.split():
-                self.word(word)
+            if not self.in_pre:
+                for word in tok.text.split():
+                    self.word(word)
+            else:
+                for word in tok.text.split("\n"):
+                    self.word(word)
+                    if not word:
+                        self.flush()
         else:
             match tok.tag:
                 case "i":
@@ -50,34 +63,48 @@ class Layout:
                     self.abbr = True
                 case "/abbr":
                     self.abbr = False
+                case "pre":
+                    self.in_pre = True
+                    self.family = "Courier New"
+                case "/pre":
+                    self.in_pre = False
+                    self.family = None
+
+    def _handle_soft_hyphen(self, word: str, font: tkinter.font.Font) -> None:
+        # If word has a soft hyphen, append string before hyphen to the current
+        # line, start a new line, and call .word on the rest of the word
+        split_text = word.split("&shy;", 1)
+        self.line.append(LineItem(x=self.cursor_x, text=split_text[0] + "-", font=font))
+        self.flush()
+        self.word(split_text[1])
+
+    def _handle_abbr(
+        self, word: str, font: tkinter.font.Font
+    ) -> tuple[str, tkinter.font.Font]:
+        for char in word:
+            if char.islower() and char.isalpha():
+                font = get_font(self.size - 2, "bold", self.style)
+                word, font = word.replace(char, char.upper())
+        return word, font
 
     def word(self, word: str) -> None:
-        font = get_font(self.size, self.weight, self.style)
+        font = get_font(self.size, self.weight, self.style, self.family)
         if self.abbr:
-            for char in word:
-                if char.islower() and char.isalpha():
-                    font = get_font(self.size - 2, "bold", self.style)
-                    word = word.replace(char, char.upper())
+            word, font = self._handle_abbr(word, font)
         w = font.measure(word)
 
         if self.cursor_x + w > self.width - HSTEP - SCROLLBAR_WIDTH:
             if "&shy;" in word:
-                # If word has a soft hyphen, append string before hyphen
-                # to the current line, start a new line,
-                # and call .word on the rest of the word
-                split_text = word.split("&shy;", 1)
-                self.line.append(
-                    LineItem(x=self.cursor_x, text=split_text[0], font=font)
-                )
-                self.flush()
-                self.word(split_text[1])
-                return
+                return self._handle_soft_hyphen(word, font)
             self.flush()
         elif "&shy;" in word:
             word = word.replace("&shy;", "")
 
         self.line.append(LineItem(x=self.cursor_x, text=word, font=font))
-        self.cursor_x += w + font.measure(" ")
+        if self.in_pre:
+            self.cursor_x += w
+        else:
+            self.cursor_x += w + font.measure(" ")
 
         # Increase cursor_y if the character is a newline
         if word == "\n":
@@ -129,6 +156,8 @@ class Layout:
         self.size: int = 12
         self.alignment: Enum = Alignment.RIGHT
         self.abbr: bool = False
+        self.in_pre: bool = False
+        self.family = None
 
         for tok in tokens:
             self.token(tok)
@@ -138,9 +167,9 @@ class Layout:
 
 # Convert raw response body to a list of parsed Tags and Text
 def lex(body: str, view_source: bool = False) -> list[Tag | Text]:
-    buffer = ""
+    buffer: str = ""
     out: list[Tag | Text] = []
-    in_tag = False
+    in_tag: bool = False
 
     title = re.search("<title>(.*)</title>", body)
     title_text = ""
@@ -149,6 +178,7 @@ def lex(body: str, view_source: bool = False) -> list[Tag | Text]:
     body = body.replace(title_text, "")
 
     if view_source:
+        body = replace_character_references(body)
         out.append(Text(body))
         return out
 
@@ -166,4 +196,5 @@ def lex(body: str, view_source: bool = False) -> list[Tag | Text]:
             buffer += c
     if not in_tag and buffer:
         out.append(Text(buffer))
+
     return out

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -53,7 +53,9 @@ class TestLayout:
         ]
         layout = Layout(text)
         assert len(layout.display_list) == 2
-        assert layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
+        assert (
+            layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
+        )
         assert layout.display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         # Both words should start at the beginning of the line
         assert layout.display_list[0].x == layout.display_list[1].x
@@ -73,6 +75,8 @@ class TestLayout:
         ]
         layout = Layout(text)
         assert len(layout.display_list) == 3
-        assert layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
-        assert layout.display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert (
+            layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
+        )
+        assert layout.display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
         assert layout.display_list[2].text == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"


### PR DESCRIPTION
* Apply monospaced font family within all elements of the `pre` tag, and respect nested tag formatting
* In `token()`, instead of calling `self.word` for each word, apply it line by line so whitespace is preserved
* Small fix to soft hyphen implementation (I forgot the actual hyphen lol) and clean up `word` function a bit
* TODO: add tests for `pre` tag