### PR TITLE
Chapter 4: add basic parser tests

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -100,18 +100,20 @@ class HTMLParser:
         return tag, attributes
 
     def parse(self) -> Element | Text:
-        text: str = ""
-        in_tag = False
-
         title = re.search("<title>(.*)</title>", self.body)
-        title_text = ""
         if title:
-            title_text = title.group(1)
-        self.body = self.body.replace(title_text, "")
+            self.body = self.body.replace(title.group(1), "")
 
         if self.view_source:
             self.add_text(self.body)
             return self.finish()
+
+        self._parse_body()
+        return self.finish()
+
+    def _parse_body(self) -> None:
+        text: str = ""
+        in_tag = False
 
         for c in self.body:
             if c == "<":
@@ -128,7 +130,6 @@ class HTMLParser:
 
         if not in_tag and text:
             self.add_text(text)
-        return self.finish()
 
     def add_text(self, text: str) -> None:
         if text.isspace():

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -29,7 +29,7 @@ def mock_http_response(text):
 
 
 class TestBrowser:
-    def test_browser_load_display_list(self, mock_socket):
+    def test_browser_loads_display_list(self, mock_socket):
         browser = mock_socket()
         assert len(browser.display_list) == 2
         first_word = browser.display_list[0]
@@ -45,7 +45,7 @@ class TestBrowser:
         # Words should have the same y coordinate
         assert first_word.y == second_word.y
 
-    def test_browser_load_rtl(self, mock_socket):
+    def test_browser_loads_rtl(self, mock_socket):
         browser = mock_socket(rtl=True)
         assert len(browser.display_list) == 2
         first_word = browser.display_list[0]
@@ -62,7 +62,7 @@ class TestBrowser:
         # span entire width
         assert first_word.x > HSTEP
 
-    def test_browser_resize_width(self, mock_socket):
+    def test_browser_resizes_width(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
         assert browser.screen_width == WIDTH
 
@@ -76,7 +76,7 @@ class TestBrowser:
         assert all(item.x < browser.screen_width for item in browser.display_list)
         assert all(item.x >= HSTEP for item in browser.display_list)
 
-    def test_browser_resize_height(self, mock_socket):
+    def test_browser_resizes_height(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
         assert browser.screen_height == HEIGHT
         previous_doc_height = browser.display_list[-1].y
@@ -90,7 +90,7 @@ class TestBrowser:
         # display_list[-1][1] is the last y coordinate of the document
         assert browser.display_list[-1].y != previous_doc_height
 
-    def test_browser_scrollbar_align_after_resize(self, mock_socket):
+    def test_browser_scrollbar_aligns_after_resize(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
         e = tkinter.Event()
         e.height = 400
@@ -110,7 +110,7 @@ class TestBrowser:
         assert len(browser.display_list) == 1
         assert browser.display_list[0].text == "<b>bodytext</b>"
 
-    def test_browser_http_does_not_render_tag(self, mock_socket):
+    def test_browser_without_view_source_does_not_render_tag(self, mock_socket):
         browser = mock_socket(response_body_text=b"<b>bodytext</b>")
         assert len(browser.display_list) == 1
         assert browser.display_list[0].text == "bodytext"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -40,6 +40,18 @@ class TestLayout:
         assert word1.font.size == 10
         assert word1.font.weight == "bold"
 
+    def test_abbr_tag_respects_mixed_casing(self):
+        # This doesn't pass the specifications in the exercise, as it
+        # still bolds the uppercase letters in e.g. JsOn
+        tree = HTMLParser("<head><abbr>JsOn 123</abbr>").parse()
+        layout = Layout(tree)
+        assert len(layout.display_list) == 2
+        word1 = layout.display_list[0]
+        assert word1.text == "JSON"
+        assert word1.font.weight == "bold"
+        word2 = layout.display_list[1]
+        assert word2.font.weight == "normal"
+
     def test_soft_hyphen_breaks_long_line(self):
         tree = HTMLParser(
             "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -90,15 +102,3 @@ class TestLayout:
         assert len(layout.display_list) == 2
         assert layout.display_list[1].font.weight == "bold"
         assert layout.display_list[1].font.family == "Courier New"
-
-    def test_abbr_tag_respects_mixed_casing(self):
-        # This doesn't pass the specifications in the exercise, as it
-        # still bolds the uppercase letters in e.g. JsOn
-        tree = HTMLParser("<head><abbr>JsOn 123</abbr>").parse()
-        layout = Layout(tree)
-        assert len(layout.display_list) == 2
-        word1 = layout.display_list[0]
-        assert word1.text == "JSON"
-        word2 = layout.display_list[1]
-        assert word2.text == "123"
-        assert word2.font.weight == "normal"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,35 @@
+import pytest
+from parser import HTMLParser
+
+
+class TestParser:
+    @pytest.mark.parametrize(
+        "input", ["test", "<body>test", "<html><body>test</body></html>"]
+    )
+    def test_parses_tags_and_adds_missing(self, input):
+        parsed = HTMLParser(input).parse()
+        assert str(parsed) == "<html>"
+        assert len(parsed.children) == 1
+        child = parsed.children[0]
+        assert str(child) == "<body>"
+        assert len(child.children) == 1
+        assert child.children[0].text == "test"
+
+    def test_head_tags_placed_in_head(self):
+        parsed = HTMLParser(
+            "<base><basefont></basefont><title></title><div></div>"
+        ).parse()
+        assert str(parsed) == "<html>"
+
+        # <html> should have <head> and <body> nested beneath
+        assert len(parsed.children) == 2
+        head_tag = parsed.children[0]
+        assert str(head_tag) == "<head>"
+        assert len(head_tag.children) == 3
+        assert str(head_tag.children[0]) == "<base>"
+        assert str(head_tag.children[1]) == "<basefont>"
+        assert str(head_tag.children[2]) == "<title>"
+        body_tag = parsed.children[1]
+        assert str(body_tag) == "<body>"
+        assert len(body_tag.children) == 1
+        assert str(body_tag.children[0]) == "<div>"


### PR DESCRIPTION
Add some basic unit tests for HTML parser
* Test `<html>`, `<head>`, and `<body>` tags are parsed and added if any are missing (uses `pytest` parameterized tests!)
* Test that elements are added to the correct parent element (`<div>` added to `<body>`)