### PR TITLE
Exercise 4.1, support HTML comments

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -114,26 +114,24 @@ class HTMLParser:
     def _parse_body(self) -> None:
         text: str = ""
         in_tag, in_comment = False, False
+        body_length = len(self.body)
 
         for i, c in enumerate(self.body):
             if c == "<":
                 if in_comment:
                     continue
-                in_tag = True
-                if i + 4 < len(self.body) and self.body[i + 1 : i + 4] == "!--":
+                if i + 4 < body_length and self.body[i + 1 : i + 4] == "!--":
                     in_comment = True
-                    continue
+                in_tag = True
                 if text:
-                    # Open tag marks the end of existing text, so create text node
                     self.add_text(text)
                 text = ""
             elif c == ">":
                 in_tag = False
-                if self.body[i - 2 : i] == "--" and in_comment:
+                if i - 2 > 0 and self.body[i - 2 : i] == "--" and in_comment:
                     in_comment = False
                     text = ""
                     continue
-                # Close tag marks the beginning of tag, so create node
                 self.add_tag(text)
                 text = ""
             else:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,3 +33,14 @@ class TestParser:
         assert str(body_tag) == "<body>"
         assert len(body_tag.children) == 1
         assert str(body_tag.children[0]) == "<div>"
+
+    def test_skips_creating_nodes_for_comments(self):
+        parsed = HTMLParser("<div><!-- ab<>cd !--></div>").parse()
+        assert str(parsed) == "<html>"
+        assert len(parsed.children) == 1
+        child = parsed.children[0]
+        assert str(child) == "<body>"
+        assert len(child.children) == 1
+        assert str(child.children[0]) == "<div>"
+        div = child.children[0]
+        assert len(div.children) == 0


### PR DESCRIPTION
* In the HTML lexer, skip creating tags for comments (and tags nested within comments) by checking for the presence of comment strings in `self.body` before creating any tag. If we're within a comment, we set `in_comment` to `True` and ignore creating text or tags until we see the closing comment tag
* To do: look into a smarter way to detect comments without modifying the parsing code by checking in `add_tag` and `add_text` instead?