### PR TITLE
Exercise 4.2, handle nested <p> tags

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -38,10 +38,6 @@ class Browser:
         self.nodes: Element | Text = HTMLParser(
             body, view_source=url.view_source
         ).parse()
-
-        from parser import print_tree
-
-        print_tree(self.nodes)
         self.display_list = Layout(
             tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list

--- a/browser.py
+++ b/browser.py
@@ -38,6 +38,10 @@ class Browser:
         self.nodes: Element | Text = HTMLParser(
             body, view_source=url.view_source
         ).parse()
+
+        from parser import print_tree
+
+        print_tree(self.nodes)
         self.display_list = Layout(
             tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list

--- a/constants.py
+++ b/constants.py
@@ -22,3 +22,33 @@ class Style(Enum):
 class Weight(Enum):
     BOLD = "bold"
     NORMAL = "normal"
+
+
+SELF_CLOSING_TAGS = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+]
+HEAD_TAGS = [
+    "base",
+    "basefont",
+    "bgsound",
+    "noscript",
+    "link",
+    "meta",
+    "title",
+    "style",
+    "script",
+]
+SIBLING_TAGS = ["p", "li"]

--- a/parser.py
+++ b/parser.py
@@ -25,7 +25,7 @@ class Element:
         self.attributes: Optional[dict] = attributes
 
     def __repr__(self) -> str:
-        return f"<{self.tag}>" + f"{self.attributes}"
+        return f"<{self.tag}>"
 
 
 class HTMLParser:
@@ -182,7 +182,7 @@ class HTMLParser:
         tags_to_finish = []
 
         # If <p> is nested within another <p> tag, finish the first tag and create another
-        if parent and parent.tag in self.SIBLING_TAGS:
+        if parent and parent.tag in self.SIBLING_TAGS and parent.tag == tag:
             parent_p_tag: Element = self.unfinished.pop()
             parent = self.unfinished[-1]
             if parent:

--- a/parser.py
+++ b/parser.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional, Tuple
+from constants import SELF_CLOSING_TAGS, HEAD_TAGS, SIBLING_TAGS
 
 
 class Text:
@@ -27,36 +28,16 @@ class Element:
     def __repr__(self) -> str:
         return f"<{self.tag}>"
 
+    def __str__(self) -> str:
+        child_strings = ""
+        for child in self.children:
+            child_strings += str(child)
+
+        close_tag = "" if self.tag in SELF_CLOSING_TAGS else f"</{self.tag}>"
+        return f"<{self.tag}>{child_strings}{close_tag}"
+
 
 class HTMLParser:
-    SELF_CLOSING_TAGS = [
-        "area",
-        "base",
-        "br",
-        "col",
-        "embed",
-        "hr",
-        "img",
-        "input",
-        "link",
-        "meta",
-        "param",
-        "source",
-        "track",
-        "wbr",
-    ]
-    HEAD_TAGS = [
-        "base",
-        "basefont",
-        "bgsound",
-        "noscript",
-        "link",
-        "meta",
-        "title",
-        "style",
-        "script",
-    ]
-    SIBLING_TAGS = ["p", "li"]
 
     def replace_character_references(self, s: str) -> str:
         s = s.replace("&lt;", "<")
@@ -74,13 +55,11 @@ class HTMLParser:
             if open_tags == [] and tag != "html":
                 self.add_tag("html")
             elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
-                if tag in self.HEAD_TAGS:
+                if tag in HEAD_TAGS:
                     self.add_tag("head")
                 else:
                     self.add_tag("body")
-            elif (
-                open_tags == ["html", "head"] and tag not in ["/head"] + self.HEAD_TAGS
-            ):
+            elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
                 self.add_tag("/head")
             else:
                 break
@@ -165,43 +144,44 @@ class HTMLParser:
             parent: Optional[Element] = self.unfinished[-1]
             if parent:
                 parent.children.append(node)
-        elif tag in self.SELF_CLOSING_TAGS:
+        elif tag in SELF_CLOSING_TAGS:
             parent = self.unfinished[-1]
             node = Element(tag=tag, attributes=attributes, parent=parent)
             parent.children.append(node)
         else:
-            if tag in self.SIBLING_TAGS:
+            if tag in SIBLING_TAGS:
                 self.handle_nested_tags(tag, attributes)
             else:
                 parent = self.unfinished[-1] if self.unfinished else None
                 node = Element(tag=tag, attributes=attributes, parent=parent)
                 self.unfinished.append(node)
 
-    def handle_nested_tags(self, tag, attributes):
+    # TODO: clean this up, handle <li> tags
+    def handle_nested_tags(self, tag, attributes) -> None:
         parent = self.unfinished[-1] if self.unfinished else None
         tags_to_finish = []
 
         # If <p> is nested within another <p> tag, finish the first tag and create another
-        if parent and parent.tag in self.SIBLING_TAGS and parent.tag == tag:
+        if parent and parent.tag in SIBLING_TAGS and parent.tag == tag:
             parent_p_tag: Element = self.unfinished.pop()
             parent = self.unfinished[-1]
             if parent:
                 parent.children.append(parent_p_tag)
                 parent = parent_p_tag
-        # If the parent isn't a direct <p> tag, look for parent p tag in the descendants
+        # If the parent tag isn't the same, look for parent p tag in the descendents
         elif any(item.tag == "p" for item in self.unfinished):
             while self.unfinished:
                 last_node = self.unfinished.pop()
                 if last_node.tag == "p":
                     break
                 tags_to_finish.append(last_node)
-            # Add tags to finish as children of parent p tag
+            # Add tags to finish as children of parent tag
             tags_to_finish.reverse()
             node_to_append = last_node
             for item in tags_to_finish:
                 node_to_append.children.append(item)
                 node_to_append = item
-            # Parent p tag is finished, so append it to the last unfinished node
+            # Parent tag is finished, so append it to the last unfinished node
             self.unfinished[-1].children.append(last_node)
         node = Element(tag=tag, attributes=attributes, parent=parent)
         self.unfinished.append(node)

--- a/parser.py
+++ b/parser.py
@@ -56,6 +56,7 @@ class HTMLParser:
         "style",
         "script",
     ]
+    SIBLING_TAGS = ["p", "li"]
 
     def replace_character_references(self, s: str) -> str:
         s = s.replace("&lt;", "<")
@@ -170,6 +171,12 @@ class HTMLParser:
             parent.children.append(node)
         else:
             parent = self.unfinished[-1] if self.unfinished else None
+            # If we see a `p` tag nested within an unfinished `p` tag, add a closing
+            # `p` tag - why is the other closing `p` tag not created?
+            if tag in self.SIBLING_TAGS and parent and parent.tag in self.SIBLING_TAGS:
+                node = Element(tag=f"/{tag}", attributes=attributes, parent=parent)
+                parent.children.append(node)
+
             node = Element(tag=tag, attributes=attributes, parent=parent)
             self.unfinished.append(node)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,53 +8,25 @@ class TestParser:
     )
     def test_parses_tags_and_adds_missing(self, input):
         parsed = HTMLParser(input).parse()
-        assert parsed.tag == "html"
-        assert len(parsed.children) == 1
-        child = parsed.children[0]
-        assert child.tag == "body"
-        assert len(child.children) == 1
-        assert child.children[0].text == "test"
+        assert str(parsed) == "<html><body>'test'</body></html>"
 
-    def test_head_tags_placed_in_head(self):
+    def test_places_title_in_missing_head_tag(self):
         parsed = HTMLParser(
             "<base><basefont></basefont><title></title><div></div>"
         ).parse()
-        assert parsed.tag == "html"
-        # <html> should have <head> and <body> nested beneath
-        assert len(parsed.children) == 2
-        head_tag = parsed.children[0]
-        assert head_tag.tag == "head"
-        assert len(head_tag.children) == 3
-        assert head_tag.children[0].tag == "base"
-        assert head_tag.children[1].tag == "basefont"
-        assert head_tag.children[2].tag == "title"
-        body_tag = parsed.children[1]
-        assert body_tag.tag == "body"
-        assert len(body_tag.children) == 1
-        assert body_tag.children[0].tag == "div"
+        assert (
+            str(parsed)
+            == "<html><head><base><basefont></basefont><title></title></head><body><div></div></body></html>"
+        )
 
     def test_skips_creating_nodes_for_comments(self):
         parsed = HTMLParser("<div><!-- ab<>cd--></div>").parse()
-        assert parsed.tag == "html"
-        assert len(parsed.children) == 1
-        child = parsed.children[0]
-        assert child.tag == "body"
-        assert len(child.children) == 1
-        assert child.children[0].tag == "div"
-        div = child.children[0]
-        assert len(div.children) == 0
+        assert str(parsed) == "<html><body><div></div></body></html>"
 
     def test_comments_ignored_when_adjacent_to_elements(self):
         parsed = HTMLParser(
             "<div><!-- ab<>cd-->test<!--comment--></div><p>test2</p>"
         ).parse()
-        assert parsed.tag == "html"
-        assert len(parsed.children) == 1
-        child = parsed.children[0]
-        assert child.tag == "body"
-        assert len(child.children) == 2
-        assert child.children[0].tag == "div"
-        div = child.children[0]
-        p = child.children[1]
-        assert div.children[0].text == "test"
-        assert p.children[0].text == "test2"
+        assert (
+            str(parsed) == "<html><body><div>'test'</div><p>'test2'</p></body></html>"
+        )


### PR DESCRIPTION
This PR handles the following HTML:
```
<p>hello<p>world</p>
```
parsing it as if it were:
```
<p>hello</p>
<p>world</p>
```
It also handles nested tags, e.g. `<p><b>hello<p>world</b></p>`, applying the `<b>` tag to both `<p>` elements.

This PR also includes a bit of test refactoring to write and use `str(node)`, instead of manually inspecting child node properties
