### PR TITLE
Exercise 4.5, syntax highlighting for view-source scheme

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -42,14 +42,9 @@ class Browser:
         if not body:
             return
         if url.view_source:
-            self.nodes: Element | Text = ViewSourceHTMLParser(
-                body, view_source=url.view_source
-            ).parse()
-            print_tree(self.nodes)
+            self.nodes: Element | Text = ViewSourceHTMLParser(body).parse()
         else:
-            self.nodes: Element | Text = HTMLParser(
-                body, view_source=url.view_source
-            ).parse()
+            self.nodes: Element | Text = HTMLParser(body).parse()
         self.display_list = Layout(
             tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list

--- a/src/browser.py
+++ b/src/browser.py
@@ -1,12 +1,18 @@
 import argparse
 import tkinter
 import tkinter.font
-from parser import HTMLParser, Element, Text
+from parser import HTMLParser, Element, Text, ViewSourceHTMLParser
 
 from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, VSTEP, WIDTH
 from layout import Layout
 from typedclasses import ScrollbarCoordinate
 from url import URL
+
+
+def print_tree(node, indent=0):
+    print(" " * indent, node)
+    for child in node.children:
+        print_tree(child, indent + 2)
 
 
 class Browser:
@@ -35,9 +41,15 @@ class Browser:
         body = url.request()
         if not body:
             return
-        self.nodes: Element | Text = HTMLParser(
-            body, view_source=url.view_source
-        ).parse()
+        if url.view_source:
+            self.nodes: Element | Text = ViewSourceHTMLParser(
+                body, view_source=url.view_source
+            ).parse()
+            print_tree(self.nodes)
+        else:
+            self.nodes: Element | Text = HTMLParser(
+                body, view_source=url.view_source
+            ).parse()
         self.display_list = Layout(
             tree=self.nodes, width=self.screen_width, rtl=self.rtl
         ).display_list

--- a/src/parser.py
+++ b/src/parser.py
@@ -51,10 +51,9 @@ class HTMLParser:
         s = s.replace("&gt;", ">")
         return s
 
-    def __init__(self, body: str, view_source: bool = False) -> None:
+    def __init__(self, body: str) -> None:
         self.body: str = body
         self.unfinished: list[Element] = []
-        self.view_source: bool = view_source
 
     def implicit_tags(self, tag: Optional[str] = None) -> None:
         while True:
@@ -231,8 +230,8 @@ class HTMLParser:
 
 class ViewSourceHTMLParser(HTMLParser):
     # view-source creates only text nodes and bold tag nodes.
-    # We add a <b> tag before parsing actual text, and treat everything
-    # else as if it were text text.
+    # We add a <b> tag before parsing actual text, and treat other
+    # tags as if they were text, not tags.
 
     def lexer(self) -> None:
         IN_TAG, IN_TEXT = False, False

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -104,13 +104,17 @@ class TestBrowser:
 
     def test_browser_view_source_renders_tags(self):
         socket.patch().start()
-        socket.respond("http://example.org/", mock_http_response(b"<b>bodytext</b>"))
+        socket.respond(
+            "http://example.org/", mock_http_response(b"<html><body></body></html>")
+        )
         browser = Browser()
         browser.load(URL("view-source:http://example.org"))
-        assert len(browser.display_list) == 1
-        assert browser.display_list[0].text == "<b>bodytext</b>"
+        assert len(browser.display_list) == 4
+        assert browser.display_list[0].text == "<html>"
+        assert browser.display_list[1].text == "<body>"
+        assert browser.display_list[2].text == "</body>"
+        assert browser.display_list[3].text == "</html>"
 
     def test_browser_without_view_source_does_not_render_tag(self, mock_socket):
-        browser = mock_socket(response_body_text=b"<b>bodytext</b>")
-        assert len(browser.display_list) == 1
-        assert browser.display_list[0].text == "bodytext"
+        browser = mock_socket(response_body_text=b"<html><body></body></html>")
+        assert len(browser.display_list) == 0


### PR DESCRIPTION
This isn't how syntax highlighting works in e.g. Firefox, but this PR bolds text outside of tags when requesting the view-source scheme by subclassing `HTMLParser` and rewriting `lexer` to:
- Create text nodes for source code tags
- Insert a bold tag node before the non-tag text
- Create text nodes for text
- Close bold tag nodes after text