### PR TITLE
Implement chapter 5, layout tree

### DIFF
--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -14,7 +14,7 @@ from constants import (
 )
 from draw import DrawRect, DrawText
 from font_cache import get_font
-from typedclasses import DisplayListItem, LineItem
+from typedclasses import LineItem
 from parser import Text, Element
 from typing import Literal, Optional
 
@@ -230,7 +230,6 @@ class BlockLayout:
                 self.children.append(next)
                 previous = next
         else:
-            # cursor_x and cursor_y are relative to x and y, so start at 0
             self.cursor_x: int = 0
             self.cursor_y: int = 0
             self.weight, self.style = Weight.NORMAL.value, Style.ROMAN.value

--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -30,6 +30,31 @@ class BlockLayout:
     weight: Literal["bold", "normal"]
     family: Optional[str]
 
+    def __init__(
+        self,
+        node: Element | Text,
+        parent,
+        previous,
+        width: int = 0,
+        rtl: bool = False,
+    ):
+        self.node = node
+        self.parent = parent
+        self.previous = previous
+        self.children: list[BlockLayout] = []
+        self.width: int = width
+        # height is a public field and always contains the correct value;
+        # cursor_y changes as we lay out paragraphs and sometimes "wrong"
+        self.height: int = 0
+        self.rtl = rtl
+        self.in_pre = False
+        self.family = None
+        self.abbr: bool = False
+        self.alignment: Enum = Alignment.RIGHT
+        self.display_list: list[DrawText | DrawRect] = []
+        self.x: int = 0
+        self.y: int = 0
+
     def _handle_soft_hyphen(self, word: str, font: tkinter.font.Font) -> None:
         # If word has a soft hyphen, append string before hyphen to the current
         # line, start a new line, and call .word on the rest of the word
@@ -163,31 +188,6 @@ class BlockLayout:
                 self.recurse(child)
             self.close_tag(tree.tag, tree.attributes)
 
-    def __init__(
-        self,
-        node: Element | Text,
-        parent,
-        previous,
-        width: int = 0,
-        rtl: bool = False,
-    ):
-        self.node = node
-        self.parent = parent
-        self.previous = previous
-        self.children: list[BlockLayout] = []
-        self.width: int = width
-        # height is a public field and always contains the correct value;
-        # cursor_y changes as we lay out paragraphs and sometimes "wrong"
-        self.height: int = 0
-        self.rtl = rtl
-        self.in_pre = False
-        self.family = None
-        self.abbr: bool = False
-        self.alignment: Enum = Alignment.RIGHT
-        self.display_list: list[DrawText | DrawRect] = []
-        self.x: int = 0
-        self.y: int = 0
-
     def layout_mode(self) -> str:
         if isinstance(self.node, Text):
             return INLINE_LAYOUT
@@ -217,7 +217,7 @@ class BlockLayout:
         if mode == BLOCK_LAYOUT:
             previous = None
             for child in self.node.children:
-                next = BlockLayout(child, self, previous)
+                next = BlockLayout(child, self, previous, rtl=self.rtl)
                 self.children.append(next)
                 previous = next
         else:

--- a/src/browser.py
+++ b/src/browser.py
@@ -54,7 +54,6 @@ class Browser:
             self.nodes = ViewSourceHTMLParser(body).parse()
         else:
             self.nodes = HTMLParser(body).parse()
-        print_tree(self.nodes)
         self.document = DocumentLayout(node=self.nodes)
         self.document.layout()
         self.display_list = []
@@ -98,7 +97,7 @@ class Browser:
             )
 
     def draw(self):
-        self.canvas.delete("all")
+        self.canvas.delete("text")
         for cmd in self.display_list:
             if cmd.top > self.scroll + self.screen_height:
                 continue
@@ -132,6 +131,8 @@ class Browser:
     def resize(self, e: tkinter.Event) -> None:
         self.screen_height = e.height
         self.screen_width = e.width
+        self.document = DocumentLayout(node=self.nodes, width=e.width)
+        self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)
         self.draw()

--- a/src/browser.py
+++ b/src/browser.py
@@ -1,10 +1,10 @@
 import argparse
 import tkinter
 import tkinter.font
+from document_layout import DocumentLayout
 from parser import HTMLParser, Element, Text, ViewSourceHTMLParser
 
 from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, VSTEP, WIDTH
-from layout import Layout
 from typedclasses import ScrollbarCoordinate
 from url import URL
 
@@ -13,6 +13,13 @@ def print_tree(node, indent=0):
     print(" " * indent, node)
     for child in node.children:
         print_tree(child, indent + 2)
+
+
+def paint_tree(layout_object, display_list):
+    display_list.extend(layout_object.paint())
+
+    for child in layout_object.children:
+        paint_tree(child, display_list)
 
 
 class Browser:
@@ -46,9 +53,12 @@ class Browser:
             self.nodes = ViewSourceHTMLParser(body).parse()
         else:
             self.nodes = HTMLParser(body).parse()
-        self.display_list = Layout(
-            tree=self.nodes, width=self.screen_width, rtl=self.rtl
-        ).display_list
+        self.document = DocumentLayout(
+            node=self.nodes  # , width=self.screen_width, rtl=self.rtl
+        )
+        self.document.layout()
+        self.display_list = []
+        paint_tree(self.document, self.display_list)
         self.draw()
 
     # Exercise 2.4
@@ -129,9 +139,8 @@ class Browser:
     def resize(self, e: tkinter.Event) -> None:
         self.screen_height = e.height
         self.screen_width = e.width
-        self.display_list = Layout(
-            tree=self.nodes, width=self.screen_width, rtl=self.rtl
-        ).display_list
+        self.display_list = []
+        paint_tree(self.document, self.display_list)
         self.draw()
 
 

--- a/src/browser.py
+++ b/src/browser.py
@@ -54,7 +54,7 @@ class Browser:
             self.nodes = ViewSourceHTMLParser(body).parse()
         else:
             self.nodes = HTMLParser(body).parse()
-        self.document = DocumentLayout(node=self.nodes)
+        self.document = DocumentLayout(node=self.nodes, rtl=self.rtl)
         self.document.layout()
         self.display_list: list = []
         paint_tree(self.document, self.display_list)
@@ -131,7 +131,7 @@ class Browser:
     def resize(self, e: tkinter.Event) -> None:
         self.screen_height = e.height
         self.screen_width = e.width
-        self.document = DocumentLayout(node=self.nodes, width=e.width)
+        self.document = DocumentLayout(node=self.nodes, width=e.width, rtl=self.rtl)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/browser.py
+++ b/src/browser.py
@@ -56,7 +56,7 @@ class Browser:
             self.nodes = HTMLParser(body).parse()
         self.document = DocumentLayout(node=self.nodes)
         self.document.layout()
-        self.display_list = []
+        self.display_list: list = []
         paint_tree(self.document, self.display_list)
         self.draw()
 
@@ -98,7 +98,6 @@ class Browser:
 
     def draw(self):
         self.canvas.delete("text")
-        print("display list", self.display_list)
         for cmd in self.display_list:
             if cmd.top > self.scroll + self.screen_height:
                 continue

--- a/src/browser.py
+++ b/src/browser.py
@@ -98,6 +98,7 @@ class Browser:
 
     def draw(self):
         self.canvas.delete("text")
+        print("display list", self.display_list)
         for cmd in self.display_list:
             if cmd.top > self.scroll + self.screen_height:
                 continue

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,6 +7,47 @@ SCROLL_STEP = 100
 TEST_FILE = "/Users/margotkriete/Desktop/test.html"
 SCROLLBAR_WIDTH = 20
 PORTS = {"http": 80, "https": 443}
+INLINE_LAYOUT = "inline"
+BLOCK_LAYOUT = "block"
+BLOCK_ELEMENTS = [
+    "html",
+    "body",
+    "article",
+    "section",
+    "nav",
+    "aside",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hgroup",
+    "header",
+    "footer",
+    "address",
+    "p",
+    "hr",
+    "pre",
+    "blockquote",
+    "ol",
+    "ul",
+    "menu",
+    "li",
+    "dl",
+    "dt",
+    "dd",
+    "figure",
+    "figcaption",
+    "main",
+    "div",
+    "table",
+    "form",
+    "fieldset",
+    "legend",
+    "details",
+    "summary",
+]
 
 
 class Alignment(Enum):

--- a/src/document_layout.py
+++ b/src/document_layout.py
@@ -8,9 +8,9 @@ class DocumentLayout:
     def __init__(self, node, width: Optional[int] = WIDTH):
         self.node = node
         self.parent = None
-        self.children = []
+        self.children: list[BlockLayout] = []
         self.width = width
-        self.height: int = None
+        self.height: int = 0
         self.x: int = 0
         self.y: int = 0
 

--- a/src/document_layout.py
+++ b/src/document_layout.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from block_layout import BlockLayout
+from constants import WIDTH, HSTEP, VSTEP
+
+
+class DocumentLayout:
+    def __init__(self, node):
+        self.node = node
+        self.parent = None
+        self.children = []
+        self.width: Optional[int] = None
+        self.height: int = None
+        self.x: int = 0
+        self.y: int = 0
+
+    def layout(self):
+        child = BlockLayout(self.node, self, None)
+        self.children.append(child)
+        self.width = WIDTH - 2 * HSTEP
+        self.x = HSTEP
+        self.y = VSTEP
+        child.layout()
+        self.height = child.height
+
+    def paint(self):
+        return []

--- a/src/document_layout.py
+++ b/src/document_layout.py
@@ -5,11 +5,11 @@ from constants import WIDTH, HSTEP, VSTEP
 
 
 class DocumentLayout:
-    def __init__(self, node):
+    def __init__(self, node, width: Optional[int] = WIDTH):
         self.node = node
         self.parent = None
         self.children = []
-        self.width: Optional[int] = None
+        self.width = width
         self.height: int = None
         self.x: int = 0
         self.y: int = 0
@@ -17,7 +17,7 @@ class DocumentLayout:
     def layout(self):
         child = BlockLayout(self.node, self, None)
         self.children.append(child)
-        self.width = WIDTH - 2 * HSTEP
+        self.width = self.width - 2 * HSTEP
         self.x = HSTEP
         self.y = VSTEP
         child.layout()

--- a/src/document_layout.py
+++ b/src/document_layout.py
@@ -5,7 +5,7 @@ from constants import WIDTH, HSTEP, VSTEP
 
 
 class DocumentLayout:
-    def __init__(self, node, width: Optional[int] = WIDTH):
+    def __init__(self, node, width: Optional[int] = WIDTH, rtl: bool = False):
         self.node = node
         self.parent = None
         self.children: list[BlockLayout] = []
@@ -13,9 +13,10 @@ class DocumentLayout:
         self.height: int = 0
         self.x: int = 0
         self.y: int = 0
+        self.rtl = rtl
 
     def layout(self):
-        child = BlockLayout(self.node, self, None)
+        child = BlockLayout(self.node, self, None, rtl=self.rtl)
         self.children.append(child)
         self.width = self.width - 2 * HSTEP
         self.x = HSTEP

--- a/src/draw.py
+++ b/src/draw.py
@@ -1,0 +1,31 @@
+class DrawText:
+    def __init__(self, x1, y1, text, font):
+        self.top = y1
+        self.left = x1
+        self.text = text
+        self.font = font
+        self.bottom = y1 + font.metrics("linespace")
+
+    def execute(self, scroll, canvas):
+        canvas.create_text(
+            self.left, self.top - scroll, text=self.text, font=self.font, anchor="nw"
+        )
+
+
+class DrawRect:
+    def __init__(self, x1, y1, x2, y2, color):
+        self.top = y1
+        self.left = x1
+        self.bottom = y2
+        self.right = x2
+        self.color = color
+
+    def execute(self, scroll, canvas):
+        canvas.create_rectangle(
+            self.left,
+            self.top - scroll,
+            self.right,
+            self.bottom - scroll,
+            width=0,
+            fill=self.color,
+        )

--- a/src/draw.py
+++ b/src/draw.py
@@ -1,5 +1,8 @@
+import tkinter.font
+
+
 class DrawText:
-    def __init__(self, x1, y1, text, font):
+    def __init__(self, x1: int, y1: int, text: str, font: tkinter.font.Font):
         self.top = y1
         self.left = x1
         self.text = text
@@ -8,12 +11,17 @@ class DrawText:
 
     def execute(self, scroll, canvas):
         canvas.create_text(
-            self.left, self.top - scroll, text=self.text, font=self.font, anchor="nw"
+            self.left,
+            self.top - scroll,
+            text=self.text,
+            font=self.font,
+            anchor="nw",
+            tag="text",
         )
 
 
 class DrawRect:
-    def __init__(self, x1, y1, x2, y2, color):
+    def __init__(self, x1: int, y1: int, x2: int, y2: int, color: str):
         self.top = y1
         self.left = x1
         self.bottom = y2
@@ -28,4 +36,5 @@ class DrawRect:
             self.bottom - scroll,
             width=0,
             fill=self.color,
+            tag="text",
         )

--- a/src/typedclasses.py
+++ b/src/typedclasses.py
@@ -1,5 +1,6 @@
 import tkinter.font
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -39,28 +39,28 @@ class TestBrowser:
 
         # "Body" should have a smaller x coordinate than "text"
         # First word should begin at HSTEP
-        assert first_word.x < second_word.x
-        assert first_word.x == HSTEP
+        assert first_word.left < second_word.left
+        assert first_word.left == HSTEP
 
         # Words should have the same y coordinate
-        assert first_word.y == second_word.y
+        assert first_word.top == second_word.top
 
-    def test_browser_loads_rtl(self, mock_socket):
-        browser = mock_socket(rtl=True)
-        assert len(browser.display_list) == 2
-        first_word = browser.display_list[0]
-        second_word = browser.display_list[1]
-        assert first_word.text == "Body"
-        assert second_word.text == "text"
+    # def test_browser_loads_rtl(self, mock_socket):
+    #     browser = mock_socket(rtl=True)
+    #     assert len(browser.display_list) == 2
+    #     first_word = browser.display_list[0]
+    #     second_word = browser.display_list[1]
+    #     assert first_word.text == "Body"
+    #     assert second_word.text == "text"
 
-        # "Body" should have a smaller x coordinate than "text"
-        assert first_word.x < second_word.x
-        # Words should have the same y coordinate
-        assert first_word.y == second_word.y
+    #     # "Body" should have a smaller x coordinate than "text"
+    #     assert first_word.left < second_word.left
+    #     # Words should have the same y coordinate
+    #     assert first_word.top == second_word.top
 
-        # Using rtl layout, first x coordinate should be > HSTEP if line does not
-        # span entire width
-        assert first_word.x > HSTEP
+    #     # Using rtl layout, first x coordinate should be > HSTEP if line does not
+    #     # span entire width
+    #     assert first_word.left > HSTEP
 
     def test_browser_resizes_width(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
@@ -73,8 +73,8 @@ class TestBrowser:
         assert browser.screen_width == e.width
 
         # All x coordinates should be > HSTEP and < screen width
-        assert all(item.x < browser.screen_width for item in browser.display_list)
-        assert all(item.x >= HSTEP for item in browser.display_list)
+        assert all(item.left < browser.screen_width for item in browser.display_list)
+        assert all(item.left >= HSTEP for item in browser.display_list)
 
     def test_browser_resizes_height(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -79,7 +79,7 @@ class TestBrowser:
     def test_browser_resizes_height(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
         assert browser.screen_height == HEIGHT
-        previous_doc_height = browser.display_list[-1].y
+        previous_doc_height = browser.display_list[-1].bottom
         e = tkinter.Event()
         e.height = 400
         e.width = 600
@@ -88,7 +88,7 @@ class TestBrowser:
         assert browser.screen_height == e.height
         # display_list coordinates should have shifted with resize
         # display_list[-1][1] is the last y coordinate of the document
-        assert browser.display_list[-1].y != previous_doc_height
+        assert browser.display_list[-1].bottom != previous_doc_height
 
     def test_browser_scrollbar_aligns_after_resize(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)
@@ -100,7 +100,7 @@ class TestBrowser:
         assert coordinates.x0 == 1180
         assert coordinates.y0 == 0
         assert coordinates.x1 == 1200
-        assert coordinates.y1 == 652
+        assert coordinates.y1 == 621
 
     def test_browser_view_source_renders_tags(self):
         socket.patch().start()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -45,22 +45,22 @@ class TestBrowser:
         # Words should have the same y coordinate
         assert first_word.top == second_word.top
 
-    # def test_browser_loads_rtl(self, mock_socket):
-    #     browser = mock_socket(rtl=True)
-    #     assert len(browser.display_list) == 2
-    #     first_word = browser.display_list[0]
-    #     second_word = browser.display_list[1]
-    #     assert first_word.text == "Body"
-    #     assert second_word.text == "text"
+    def test_browser_loads_rtl(self, mock_socket):
+        browser = mock_socket(rtl=True)
+        assert len(browser.display_list) == 2
+        first_word = browser.display_list[0]
+        second_word = browser.display_list[1]
+        assert first_word.text == "Body"
+        assert second_word.text == "text"
 
-    #     # "Body" should have a smaller x coordinate than "text"
-    #     assert first_word.left < second_word.left
-    #     # Words should have the same y coordinate
-    #     assert first_word.top == second_word.top
+        # "Body" should have a smaller x coordinate than "text"
+        assert first_word.left < second_word.left
+        # Words should have the same y coordinate
+        assert first_word.top == second_word.top
 
-    #     # Using rtl layout, first x coordinate should be > HSTEP if line does not
-    #     # span entire width
-    #     assert first_word.left > HSTEP
+        # Using rtl layout, first x coordinate should be > HSTEP if line does not
+        # span entire width
+        assert first_word.left > HSTEP
 
     def test_browser_resizes_width(self, mock_socket):
         browser = mock_socket(response_body_text=LOREM_IPSUM)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -5,28 +5,27 @@ from browser import paint_tree
 
 
 class TestLayout:
-    def setup(self, html: str) -> list:
+    def setup(self, html: str, rtl: bool = False) -> list:
         tree = HTMLParser(html).parse()
-        document = DocumentLayout(tree)
+        document = DocumentLayout(tree, rtl=rtl)
         document.layout()
         display_list = []
         paint_tree(document, display_list)
         return display_list
 
-    # def test_rtl(self):
-    #     tree = HTMLParser("<head><p>Test1 test2</p>").parse()
-    #     layout = DocumentLayout(tree, rtl=True)
-    #     assert len(display_list) == 2
-    #     word1 = display_list[0]
+    def test_rtl(self):
+        display_list = self.setup("<head><p>Test1 test2</p>", rtl=True)
+        assert len(display_list) == 2
+        word1 = display_list[0]
 
-    #     # x coordinate of first word should be offset
-    #     assert word1.x > HSTEP
-    #     assert word1.text == "Test1"
+        # x coordinate of first word should be offset
+        assert word1.left > HSTEP
+        assert word1.text == "Test1"
 
-    #     word2 = display_list[1]
-    #     # Word 2 should lay out after word 1
-    #     assert word2.x > word1.x
-    #     assert word2.text == "test2"
+        word2 = display_list[1]
+        # Word 2 should lay out after word 1
+        assert word2.left > word1.left
+        assert word2.text == "test2"
 
     def test_h1_center_align(self):
         display_list = self.setup("<head><h1 class='title'>Test1 test2</h1>test3")

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,12 +1,12 @@
 from constants import HSTEP
-from layout import Layout
+from block_layout import BlockLayout
 from parser import Text, Element, HTMLParser
 
 
 class TestLayout:
     def test_rtl(self):
         tree = HTMLParser("<head><p>Test1 test2</p>").parse()
-        layout = Layout(tree, rtl=True)
+        layout = BlockLayout(tree, rtl=True)
         assert len(layout.display_list) == 2
         word1 = layout.display_list[0]
 
@@ -21,7 +21,7 @@ class TestLayout:
 
     def test_h1_center_align(self):
         tree = HTMLParser("<head><h1 class='title'>Test1 test2</h1>test3").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 3
         # Ensure title is centered
         word1 = layout.display_list[0]
@@ -32,7 +32,7 @@ class TestLayout:
 
     def test_abbr_tag(self):
         tree = HTMLParser("<head><abbr>json</abbr>").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 1
         word1 = layout.display_list[0]
         assert word1.text == "JSON"
@@ -43,7 +43,7 @@ class TestLayout:
         # This doesn't pass the specifications in the exercise, as it
         # still bolds the uppercase letters in e.g. JsOn
         tree = HTMLParser("<head><abbr>JsOn 123</abbr>").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 2
         word1 = layout.display_list[0]
         assert word1.text == "JSON"
@@ -55,7 +55,7 @@ class TestLayout:
         tree = HTMLParser(
             "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ).parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 2
         assert (
             layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
@@ -67,7 +67,7 @@ class TestLayout:
 
     def test_soft_hyphen_removes_hyphen_if_word_fits(self):
         tree = HTMLParser("super­cali­fragi­list&shy;ic­expi­ali­docious").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
 
@@ -75,7 +75,7 @@ class TestLayout:
         tree = HTMLParser(
             "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&shy;bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         ).parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 3
         assert (
             layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
@@ -85,19 +85,19 @@ class TestLayout:
 
     def test_pre_tag_uses_monospaced_font(self):
         tree = HTMLParser("<pre>def get_font(self):</pre>").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].font.family == "Courier New"
 
     def test_pre_tag_maintains_whitespace(self):
         tree = HTMLParser("<pre>def get_font(self):               return</pre").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 1
         assert layout.display_list[0].text == "def get_font(self):               return"
 
     def test_pre_tag_maintains_nested_tags(self):
         tree = HTMLParser("<pre>def get_font(self):<b>return</b></pre").parse()
-        layout = Layout(tree)
+        layout = BlockLayout(tree)
         assert len(layout.display_list) == 2
         assert layout.display_list[1].font.weight == "bold"
         assert layout.display_list[1].font.family == "Courier New"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,40 +1,47 @@
 from constants import HSTEP
-from block_layout import BlockLayout
-from parser import Text, Element, HTMLParser
+from document_layout import DocumentLayout
+from parser import HTMLParser
+from browser import paint_tree
 
 
 class TestLayout:
-    def test_rtl(self):
-        tree = HTMLParser("<head><p>Test1 test2</p>").parse()
-        layout = BlockLayout(tree, rtl=True)
-        assert len(layout.display_list) == 2
-        word1 = layout.display_list[0]
+    def setup(self, html: str) -> list:
+        tree = HTMLParser(html).parse()
+        document = DocumentLayout(tree)
+        document.layout()
+        display_list = []
+        paint_tree(document, display_list)
+        return display_list
 
-        # x coordinate of first word should be offset
-        assert word1.x > HSTEP
-        assert word1.text == "Test1"
+    # def test_rtl(self):
+    #     tree = HTMLParser("<head><p>Test1 test2</p>").parse()
+    #     layout = DocumentLayout(tree, rtl=True)
+    #     assert len(display_list) == 2
+    #     word1 = display_list[0]
 
-        word2 = layout.display_list[1]
-        # Word 2 should lay out after word 1
-        assert word2.x > word1.x
-        assert word2.text == "test2"
+    #     # x coordinate of first word should be offset
+    #     assert word1.x > HSTEP
+    #     assert word1.text == "Test1"
+
+    #     word2 = display_list[1]
+    #     # Word 2 should lay out after word 1
+    #     assert word2.x > word1.x
+    #     assert word2.text == "test2"
 
     def test_h1_center_align(self):
-        tree = HTMLParser("<head><h1 class='title'>Test1 test2</h1>test3").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 3
+        display_list = self.setup("<head><h1 class='title'>Test1 test2</h1>test3")
+        assert len(display_list) == 3
         # Ensure title is centered
-        word1 = layout.display_list[0]
-        assert word1.x > HSTEP
+        word1 = display_list[0]
+        assert word1.left > HSTEP
         # Word 3 is outside of h1 tag so, should be right-aligned
-        word3 = layout.display_list[2]
-        assert word3.x == HSTEP
+        word3 = display_list[2]
+        assert word3.left == HSTEP
 
     def test_abbr_tag(self):
-        tree = HTMLParser("<head><abbr>json</abbr>").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 1
-        word1 = layout.display_list[0]
+        display_list = self.setup("<head><abbr>json</abbr>")
+        assert len(display_list) == 1
+        word1 = display_list[0]
         assert word1.text == "JSON"
         assert word1.font.size == 10
         assert word1.font.weight == "bold"
@@ -42,62 +49,51 @@ class TestLayout:
     def test_abbr_tag_respects_mixed_casing(self):
         # This doesn't pass the specifications in the exercise, as it
         # still bolds the uppercase letters in e.g. JsOn
-        tree = HTMLParser("<head><abbr>JsOn 123</abbr>").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 2
-        word1 = layout.display_list[0]
+        display_list = self.setup("<head><abbr>JsOn 123</abbr>")
+        assert len(display_list) == 2
+        word1 = display_list[0]
         assert word1.text == "JSON"
         assert word1.font.weight == "bold"
-        word2 = layout.display_list[1]
+        word2 = display_list[1]
         assert word2.font.weight == "normal"
 
     def test_soft_hyphen_breaks_long_line(self):
-        tree = HTMLParser(
+        display_list = self.setup(
             "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        ).parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 2
-        assert (
-            layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
         )
-        assert layout.display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert len(display_list) == 2
+        assert display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
+        assert display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         # Both words should start at the beginning of the line
-        assert layout.display_list[0].x == layout.display_list[1].x
-        assert layout.display_list[0].y < layout.display_list[1].y
+        assert display_list[0].left == display_list[1].left
+        assert display_list[0].bottom < display_list[1].bottom
 
     def test_soft_hyphen_removes_hyphen_if_word_fits(self):
-        tree = HTMLParser("super­cali­fragi­list&shy;ic­expi­ali­docious").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 1
-        assert layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
+        display_list = self.setup("super­cali­fragi­list&shy;ic­expi­ali­docious")
+        assert len(display_list) == 1
+        assert display_list[0].text == "super­cali­fragi­listic­expi­ali­docious"
 
     def test_soft_hyphen_handles_multiple_hyphens(self):
-        tree = HTMLParser(
+        display_list = self.setup(
             "super­cali­fragi­listic­expi­ali­docious&shy;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&shy;bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        ).parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 3
-        assert (
-            layout.display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
         )
-        assert layout.display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
-        assert layout.display_list[2].text == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        assert len(display_list) == 3
+        assert display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
+        assert display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
+        assert display_list[2].text == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     def test_pre_tag_uses_monospaced_font(self):
-        tree = HTMLParser("<pre>def get_font(self):</pre>").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 1
-        assert layout.display_list[0].font.family == "Courier New"
+        display_list = self.setup("<pre>def get_font(self):</pre>")
+        assert len(display_list) == 2
+        assert display_list[1].font.family == "Courier New"
 
     def test_pre_tag_maintains_whitespace(self):
-        tree = HTMLParser("<pre>def get_font(self):               return</pre").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 1
-        assert layout.display_list[0].text == "def get_font(self):               return"
+        display_list = self.setup("<pre>def get_font(self):               return</pre")
+        assert len(display_list) == 2
+        assert display_list[1].text == "def get_font(self):               return"
 
     def test_pre_tag_maintains_nested_tags(self):
-        tree = HTMLParser("<pre>def get_font(self):<b>return</b></pre").parse()
-        layout = BlockLayout(tree)
-        assert len(layout.display_list) == 2
-        assert layout.display_list[1].font.weight == "bold"
-        assert layout.display_list[1].font.family == "Courier New"
+        display_list = self.setup("<pre>def get_font(self):<b>return</b></pre>")
+        assert len(display_list) == 3
+        assert display_list[2].font.weight == "bold"
+        assert display_list[2].font.family == "Courier New"


### PR DESCRIPTION
* Split `Layout` into `BlockLayout` and `DocumentLayout`; `DocumentLayout` lays out the root of the layout tree and is composed of `BlockLayout` children
* Some `BlockLayout` items have nested `BlockLayout` children. These children are stacked vertically
* `layout` turns the HTML tree into a layout tree