### PR TITLE
Exercise 5.2, strip head tags from layout tree

### DIFF
--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -218,13 +218,13 @@ class BlockLayout:
         if mode == BLOCK_LAYOUT:
             previous = None
             for child in self.node.children:
-                child_is_element = isinstance(child, Element)
-                if (child_is_element and child.tag != "head") or not child_is_element:
-                    next = BlockLayout(
-                        child, self, previous, rtl=self.rtl, alignment=self.alignment
-                    )
-                    self.children.append(next)
-                    previous = next
+                if isinstance(child, Element) and child.tag == "head":
+                    continue
+                next = BlockLayout(
+                    child, self, previous, rtl=self.rtl, alignment=self.alignment
+                )
+                self.children.append(next)
+                previous = next
         else:
             self.cursor_x: int = 0
             self.cursor_y: int = 0

--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -217,9 +217,10 @@ class BlockLayout:
         if mode == BLOCK_LAYOUT:
             previous = None
             for child in self.node.children:
-                next = BlockLayout(child, self, previous, rtl=self.rtl)
-                self.children.append(next)
-                previous = next
+                if isinstance(child, Element) and child.tag != "head":
+                    next = BlockLayout(child, self, previous, rtl=self.rtl)
+                    self.children.append(next)
+                    previous = next
         else:
             self.cursor_x: int = 0
             self.cursor_y: int = 0

--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -94,7 +94,7 @@ class BlockLayout:
                 self.in_pre = True
                 self.family = "Courier New"
 
-    def close_tag(self, tag: str, attributes: Optional[dict] = None) -> None:
+    def close_tag(self, tag: str) -> None:
         match tag:
             case "i":
                 self.style = Style.ROMAN.value
@@ -187,7 +187,7 @@ class BlockLayout:
             self.open_tag(tree.tag, tree.attributes)
             for child in tree.children:
                 self.recurse(child)
-            self.close_tag(tree.tag, tree.attributes)
+            self.close_tag(tree.tag)
 
     def layout_mode(self) -> str:
         if isinstance(self.node, Text):
@@ -218,7 +218,8 @@ class BlockLayout:
         if mode == BLOCK_LAYOUT:
             previous = None
             for child in self.node.children:
-                if isinstance(child, Element) and child.tag != "head":
+                child_is_element = isinstance(child, Element)
+                if (child_is_element and child.tag != "head") or not child_is_element:
                     next = BlockLayout(
                         child, self, previous, rtl=self.rtl, alignment=self.alignment
                     )

--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -37,6 +37,7 @@ class BlockLayout:
         previous,
         width: int = 0,
         rtl: bool = False,
+        alignment: Enum = Alignment.RIGHT,
     ):
         self.node = node
         self.parent = parent
@@ -50,7 +51,7 @@ class BlockLayout:
         self.in_pre = False
         self.family = None
         self.abbr: bool = False
-        self.alignment: Enum = Alignment.RIGHT
+        self.alignment: Enum = alignment
         self.display_list: list[DrawText | DrawRect] = []
         self.x: int = 0
         self.y: int = 0
@@ -107,7 +108,7 @@ class BlockLayout:
                 self.flush()
                 self.cursor_y += VSTEP
             case "h1":
-                if attributes and attributes.get("class") == "title":
+                if self.alignment == Alignment.CENTER:
                     self.flush()
                     self.alignment = Alignment.RIGHT
             case "abbr":
@@ -218,7 +219,9 @@ class BlockLayout:
             previous = None
             for child in self.node.children:
                 if isinstance(child, Element) and child.tag != "head":
-                    next = BlockLayout(child, self, previous, rtl=self.rtl)
+                    next = BlockLayout(
+                        child, self, previous, rtl=self.rtl, alignment=self.alignment
+                    )
                     self.children.append(next)
                     previous = next
         else:

--- a/src/browser.py
+++ b/src/browser.py
@@ -3,6 +3,7 @@ import tkinter
 import tkinter.font
 from block_layout import BlockLayout
 from document_layout import DocumentLayout
+from draw import DrawRect, DrawText
 from parser import HTMLParser, Element, Text, ViewSourceHTMLParser
 
 from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, WIDTH
@@ -17,7 +18,8 @@ def print_tree(node, indent=0):
 
 
 def paint_tree(
-    layout_object: BlockLayout | DocumentLayout, display_list: list[DisplayListItem]
+    layout_object: BlockLayout | DocumentLayout,
+    display_list: list[DisplayListItem | DrawRect | DrawText],
 ):
     display_list.extend(layout_object.paint())
 

--- a/src/browser.py
+++ b/src/browser.py
@@ -1,12 +1,12 @@
 import argparse
 import tkinter
 import tkinter.font
+from block_layout import BlockLayout
 from document_layout import DocumentLayout
-from draw import DrawText
 from parser import HTMLParser, Element, Text, ViewSourceHTMLParser
 
-from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, VSTEP, WIDTH
-from typedclasses import ScrollbarCoordinate
+from constants import HEIGHT, SCROLL_STEP, SCROLLBAR_WIDTH, TEST_FILE, WIDTH
+from typedclasses import DisplayListItem, ScrollbarCoordinate
 from url import URL
 
 
@@ -16,7 +16,9 @@ def print_tree(node, indent=0):
         print_tree(child, indent + 2)
 
 
-def paint_tree(layout_object, display_list):
+def paint_tree(
+    layout_object: BlockLayout | DocumentLayout, display_list: list[DisplayListItem]
+):
     display_list.extend(layout_object.paint())
 
     for child in layout_object.children:

--- a/src/parser.py
+++ b/src/parser.py
@@ -98,9 +98,6 @@ class HTMLParser:
         return tag, attrs_dict
 
     def parse(self) -> Element | Text:
-        title = re.search("<title>(.*)</title>", self.body)
-        if title:
-            self.body = self.body.replace(title.group(1), "")
         self.lexer()
         return self.finish()
 
@@ -123,8 +120,8 @@ class HTMLParser:
             False,
         )
         body_length: int = len(self.body)
-        attributes = []
-        current_attribute = ""
+        attributes: list[str] = []
+        current_attribute: str = ""
 
         for i, c in enumerate(self.body):
             if c == '"' or c == "'":

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -28,17 +28,17 @@ class TestLayout:
         assert word2.text == "test2"
 
     def test_h1_center_align(self):
-        display_list = self.setup("<head><h1 class='title'>Test1 test2</h1>test3")
-        assert len(display_list) == 3
+        display_list = self.setup("<h1 class='title'>Test1 test2</h1>test3")
+        assert len(display_list) == 2
         # Ensure title is centered
         word1 = display_list[0]
         assert word1.left > HSTEP
         # Word 3 is outside of h1 tag so, should be right-aligned
-        word3 = display_list[2]
+        word3 = display_list[1]
         assert word3.left == HSTEP
 
     def test_abbr_tag(self):
-        display_list = self.setup("<head><abbr>json</abbr>")
+        display_list = self.setup("<abbr>json</abbr>")
         assert len(display_list) == 1
         word1 = display_list[0]
         assert word1.text == "JSON"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -29,12 +29,12 @@ class TestLayout:
 
     def test_h1_center_align(self):
         display_list = self.setup("<h1 class='title'>Test1 test2</h1>test3")
-        assert len(display_list) == 2
+        assert len(display_list) == 3
         # Ensure title is centered
         word1 = display_list[0]
         assert word1.left > HSTEP
         # Word 3 is outside of h1 tag so, should be right-aligned
-        word3 = display_list[1]
+        word3 = display_list[2]
         assert word3.left == HSTEP
 
     def test_abbr_tag(self):


### PR DESCRIPTION
* Implement exercise 5.2, stripping `head` tags from the layout tree in `BlockLayout`'s `layout` method
* Update some missing types 