### PR TITLE
Implement chapter 6: CSS parsing

### DIFF
--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -159,6 +159,12 @@ class BlockLayout:
             if tree.tag == "pre":
                 self.in_pre = True
                 self.family = "Courier New"
+            if (
+                tree.tag == "h1"
+                and tree.attributes
+                and tree.attributes.get("class") == "title"
+            ):
+                self.alignment = Alignment.CENTER
             for child in tree.children:
                 self.recurse(child)
 

--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -27,7 +27,6 @@ class BlockLayout:
     abbr: bool
     in_pre: bool
     style: Literal["roman", "italic"]
-    weight: Literal["bold", "normal"]
     family: Optional[str]
 
     def __init__(
@@ -154,19 +153,24 @@ class BlockLayout:
                     if line:
                         self.flush()
         else:
-            if tree.tag == "br":
-                self.flush()
-            if tree.tag == "pre":
-                self.in_pre = True
-                self.family = "Courier New"
-            if (
-                tree.tag == "h1"
-                and tree.attributes
-                and tree.attributes.get("class") == "title"
-            ):
-                self.alignment = Alignment.CENTER
+            self.handle_global_tag_styles(tree)
             for child in tree.children:
                 self.recurse(child)
+
+    def handle_global_tag_styles(self, tree: Element):
+        if tree.tag == "br":
+            self.flush()
+        if tree.tag == "pre":
+            self.in_pre = True
+            self.family = "Courier New"
+        if (
+            tree.tag == "h1"
+            and tree.attributes
+            and tree.attributes.get("class") == "title"
+        ):
+            self.alignment = Alignment.CENTER
+        if tree.tag == "abbr":
+            self.abbr = True
 
     def layout_mode(self) -> str:
         if isinstance(self.node, Text):
@@ -197,7 +201,7 @@ class BlockLayout:
     def _layout_inline_mode(self) -> None:
         self.cursor_x: int = 0
         self.cursor_y: int = 0
-        self.weight, self.style = Weight.NORMAL.value, Style.ROMAN.value
+        self.style = Style.ROMAN.value
         self.height = self.cursor_y
         self.size: int = 12
         self.line: list[LineItem] = []

--- a/src/browser.css
+++ b/src/browser.css
@@ -1,0 +1,8 @@
+pre {
+    background-color: gray;
+}
+a { color: blue; }
+i { font-style: italic; }
+b { font-weight: bold; }
+small { font-size: 90%; }
+big { font-size: 110%; }

--- a/src/browser.css
+++ b/src/browser.css
@@ -1,6 +1,3 @@
-pre {
-    background-color: gray;
-}
 a { color: blue; }
 i { font-style: italic; }
 b { font-weight: bold; }

--- a/src/browser.css
+++ b/src/browser.css
@@ -3,3 +3,4 @@ i { font-style: italic; }
 b { font-weight: bold; }
 small { font-size: 90%; }
 big { font-size: 110%; }
+abbr { font-size: 90%; font-weight: bold;}

--- a/src/browser.py
+++ b/src/browser.py
@@ -85,6 +85,8 @@ class Browser:
         self.document.layout()
         self.display_list: list = []
         paint_tree(self.document, self.display_list)
+        for item in self.display_list:
+            print("display list item", item.text)
         self.draw()
 
     # Exercise 2.4

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,12 +1,55 @@
 from enum import Enum
 
+# Geometry
 SCROLLBAR_WIDTH = 20
 HSTEP, VSTEP = 13, 18
 WIDTH, HEIGHT = 800, 600
 SCROLL_STEP = 100
-TEST_FILE = "/Users/margotkriete/Desktop/test.html"
 SCROLLBAR_WIDTH = 20
+
+# URL parsing
+TEST_FILE = "/Users/margotkriete/Desktop/test.html"
 PORTS = {"http": 80, "https": 443}
+
+# HTML parsing
+SELF_CLOSING_TAGS = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+]
+
+
+HEAD_TAGS = [
+    "base",
+    "basefont",
+    "bgsound",
+    "noscript",
+    "link",
+    "meta",
+    "title",
+    "style",
+    "script",
+]
+
+HEAD_TAG = "head"
+HTML_TAG = "html"
+BODY_TAG = "body"
+CLOSING_HTML_TAG = "/html"
+CLOSING_HEAD_TAG = "/head"
+SIBLING_TAGS = ["p", "li"]
+
+# Layout
 INLINE_LAYOUT = "inline"
 BLOCK_LAYOUT = "block"
 BLOCK_ELEMENTS = [
@@ -50,6 +93,7 @@ BLOCK_ELEMENTS = [
 ]
 
 
+# Styling
 class Alignment(Enum):
     RIGHT = 1
     CENTER = 2
@@ -65,41 +109,10 @@ class Weight(Enum):
     NORMAL = "normal"
 
 
-SELF_CLOSING_TAGS = [
-    "area",
-    "base",
-    "br",
-    "col",
-    "embed",
-    "hr",
-    "img",
-    "input",
-    "link",
-    "meta",
-    "param",
-    "source",
-    "track",
-    "wbr",
-]
-
-
-HEAD_TAGS = [
-    "base",
-    "basefont",
-    "bgsound",
-    "noscript",
-    "link",
-    "meta",
-    "title",
-    "style",
-    "script",
-]
-
-HEAD_TAG = "head"
-HTML_TAG = "html"
-BODY_TAG = "body"
-CLOSING_HTML_TAG = "/html"
-CLOSING_HEAD_TAG = "/head"
-
-
-SIBLING_TAGS = ["p", "li"]
+# CSS parsing
+INHERTIED_PROPERTIES = {
+    "font-size": "16px",
+    "font-style": "normal",
+    "font-weight": "normal",
+    "color": "black",
+}

--- a/src/css_parser.py
+++ b/src/css_parser.py
@@ -1,0 +1,153 @@
+from constants import INHERTIED_PROPERTIES
+from parser import Element, Text
+
+
+class TagSelector:
+    def __init__(self, tag: str):
+        self.tag: str = tag
+        self.priority: int = 1
+
+    def matches(self, node) -> bool:
+        return isinstance(node, Element) and self.tag == node.tag
+
+
+class DescendantSelector:
+    def __init__(self, ancestor: Element | Text, descendant: Element | Text):
+        self.ancestor = ancestor
+        self.descendant = descendant
+        self.priority: int = ancestor.priority + descendant.priority
+
+    def matches(self, node: Element | Text) -> bool:
+        if not self.descendant.matches(node):
+            return False
+        while node.parent:
+            if self.ancestor.matches(node.parent):
+                return True
+            node = node.parent
+        return False
+
+
+class CSSParser:
+    def __init__(self, s: str) -> None:
+        self.s: str = s
+        self.i: int = 0
+
+    def whitespace(self) -> None:
+        while self.i < len(self.s) and self.s[self.i].isspace():
+            self.i += 1
+
+    def word(self) -> str:
+        start: int = self.i
+        while self.i < len(self.s):
+            if self.s[self.i].isalnum() or self.s[self.i] in "#-.%":
+                self.i += 1
+            else:
+                break
+        if not (self.i > start):
+            raise Exception(f"parsing error: i = {self.i}, start = {start}")
+        return self.s[start : self.i]
+
+    def literal(self, literal):
+        if not (self.i < len(self.s) and self.s[self.i] == literal):
+            raise Exception(f"parsing error: i = {self.i}, literal = {literal}")
+        self.i += 1
+
+    def pair(self) -> tuple[str, str]:
+        prop: str = self.word()
+        self.whitespace()
+        self.literal(":")
+        self.whitespace()
+        val: str = self.word()
+        return prop.casefold(), val
+
+    def body(self) -> dict:
+        pairs = {}
+        while self.i < len(self.s) and self.s[self.i] != "}":
+            try:
+                prop, val = self.pair()
+                pairs[prop.casefold()] = val
+                self.whitespace()
+                self.literal(";")
+                self.whitespace()
+            except Exception as e:
+                # print(f"exception: {e}")
+                why = self.ignore_until([";", "}"])
+                if why == ";":
+                    self.literal(";")
+                    self.whitespace()
+                else:
+                    break
+        return pairs
+
+    def ignore_until(self, chars: list[str]) -> str | None:
+        while self.i < len(self.s):
+            if self.s[self.i] in chars:
+                return self.s[self.i]
+            else:
+                self.i += 1
+        return None
+
+    def selector(self) -> TagSelector | DescendantSelector:
+        out = TagSelector(self.word().casefold())
+        self.whitespace()
+        while self.i < len(self.s) and self.s[self.i] != "{":
+            tag: str = self.word()
+            descendant = TagSelector(tag.casefold())
+            out = DescendantSelector(out, descendant)
+            self.whitespace()
+        return out
+
+    def parse(self) -> list:
+        rules: list = []
+        while self.i < len(self.s):
+            try:
+                self.whitespace()
+                selector: TagSelector | DescendantSelector = self.selector()
+                self.literal("{")
+                self.whitespace()
+                body: dict = self.body()
+                self.literal("}")
+                rules.append((selector, body))
+            except Exception as e:
+                # print(f"exception in parse(): {e}")
+                why = self.ignore_until(["}"])
+                if why == "}":
+                    self.literal("}")
+                    self.whitespace()
+                else:
+                    break
+        return rules
+
+
+def style(node: Element | Text, rules: list):
+    node.style = {}
+
+    for property, default_value in INHERTIED_PROPERTIES.items():
+        if node.parent:
+            node.style[property] = node.parent.style[property]
+        else:
+            node.style[property] = default_value
+
+    # style attribute should override style sheet values
+    if isinstance(node, Element) and "style" in node.attributes:
+        pairs: dict = CSSParser(node.attributes["style"]).body()
+        for property, value in pairs.items():
+            node.style[property] = value
+
+    for selector, body in rules:
+        if not selector.matches(node):
+            continue
+        for property, value in body.items():
+            node.style[property] = value
+
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERTIED_PROPERTIES["font-size"]
+        node_pct: float = float(node.style["font-size"][:-1]) / 100
+        parent_px: float = float(parent_font_size[:-2])
+        node.style["font-size"] = f"{str(node_pct * parent_px)}px"
+
+    for child in node.children:
+        style(child, rules)

--- a/src/css_parser.py
+++ b/src/css_parser.py
@@ -1,3 +1,4 @@
+from typing import Union
 from constants import INHERTIED_PROPERTIES
 from parser import Element, Text
 
@@ -12,7 +13,11 @@ class TagSelector:
 
 
 class DescendantSelector:
-    def __init__(self, ancestor: Element | Text, descendant: Element | Text):
+    def __init__(
+        self,
+        ancestor: Union[TagSelector, "DescendantSelector"],
+        descendant: Union[TagSelector, "DescendantSelector"],
+    ):
         self.ancestor = ancestor
         self.descendant = descendant
         self.priority: int = ancestor.priority + descendant.priority
@@ -87,7 +92,7 @@ class CSSParser:
         return None
 
     def selector(self) -> TagSelector | DescendantSelector:
-        out = TagSelector(self.word().casefold())
+        out: TagSelector | DescendantSelector = TagSelector(self.word().casefold())
         self.whitespace()
         while self.i < len(self.s) and self.s[self.i] != "{":
             tag: str = self.word()
@@ -133,7 +138,7 @@ def style(node: Element | Text, rules: list):
         for property, value in body.items():
             node.style[property] = value
 
-    if isinstance(node, Element) and "style" in node.attributes:
+    if isinstance(node, Element) and node.attributes and "style" in node.attributes:
         pairs: dict = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
             node.style[property] = value

--- a/src/css_parser.py
+++ b/src/css_parser.py
@@ -70,7 +70,6 @@ class CSSParser:
                 self.literal(";")
                 self.whitespace()
             except Exception as e:
-                # print(f"exception: {e}")
                 why = self.ignore_until([";", "}"])
                 if why == ";":
                     self.literal(";")
@@ -128,16 +127,15 @@ def style(node: Element | Text, rules: list):
         else:
             node.style[property] = default_value
 
-    # style attribute should override style sheet values
-    if isinstance(node, Element) and "style" in node.attributes:
-        pairs: dict = CSSParser(node.attributes["style"]).body()
-        for property, value in pairs.items():
-            node.style[property] = value
-
     for selector, body in rules:
         if not selector.matches(node):
             continue
         for property, value in body.items():
+            node.style[property] = value
+
+    if isinstance(node, Element) and "style" in node.attributes:
+        pairs: dict = CSSParser(node.attributes["style"]).body()
+        for property, value in pairs.items():
             node.style[property] = value
 
     if node.style["font-size"].endswith("%"):

--- a/src/draw.py
+++ b/src/draw.py
@@ -12,15 +12,15 @@ class DrawText:
         self.bottom = y1 + font.metrics("linespace")
         self.color = color
 
-    def execute(self, scroll: int, canvas: tkinter.Canvas):
+    def execute(self, scroll: int, canvas):
         canvas.create_text(
             self.left,
             self.top - scroll,
             text=self.text,
             font=self.font,
+            fill=self.color,
             anchor="nw",
             tag="text",
-            fill=self.color,
         )
 
 

--- a/src/draw.py
+++ b/src/draw.py
@@ -2,12 +2,15 @@ import tkinter.font
 
 
 class DrawText:
-    def __init__(self, x1: int, y1: int, text: str, font: tkinter.font.Font):
+    def __init__(
+        self, x1: int, y1: int, text: str, font: tkinter.font.Font, color: str
+    ):
         self.top = y1
         self.left = x1
         self.text = text
         self.font = font
         self.bottom = y1 + font.metrics("linespace")
+        self.color = color
 
     def execute(self, scroll, canvas):
         canvas.create_text(
@@ -17,6 +20,7 @@ class DrawText:
             font=self.font,
             anchor="nw",
             tag="text",
+            fill=self.color,
         )
 
 

--- a/src/draw.py
+++ b/src/draw.py
@@ -12,7 +12,7 @@ class DrawText:
         self.bottom = y1 + font.metrics("linespace")
         self.color = color
 
-    def execute(self, scroll, canvas):
+    def execute(self, scroll: int, canvas: tkinter.Canvas):
         canvas.create_text(
             self.left,
             self.top - scroll,

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,16 @@
+def tree_to_list(tree, list):
+    list.append(tree)
+    for child in tree.children:
+        tree_to_list(child, list)
+    return list
+
+
+def cascade_priority(rule: tuple) -> int:
+    selector, _ = rule
+    return selector.priority
+
+
+def print_tree(node, indent=0):
+    print(" " * indent, node)
+    for child in node.children:
+        print_tree(child, indent + 2)

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,4 +1,4 @@
-def tree_to_list(tree, list):
+def tree_to_list(tree, list: list):
     list.append(tree)
     for child in tree.children:
         tree_to_list(child, list)
@@ -10,7 +10,7 @@ def cascade_priority(rule: tuple) -> int:
     return selector.priority
 
 
-def print_tree(node, indent=0):
+def print_tree(node, indent: int = 0) -> None:
     print(" " * indent, node)
     for child in node.children:
         print_tree(child, indent + 2)

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,5 +1,4 @@
-import re
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 from constants import (
     SELF_CLOSING_TAGS,
     HEAD_TAGS,
@@ -17,6 +16,8 @@ class Text:
         self.text: str = text
         self.children: list[Element | Text] = []
         self.parent: Element = parent
+        self.style: dict = {}
+        self.priority: int = 0
 
     def __repr__(self) -> str:
         return repr(self.text)
@@ -33,6 +34,8 @@ class Element:
         self.children: list[Element | Text] = []
         self.parent: Optional[Element] = parent
         self.attributes: Optional[dict] = attributes
+        self.style: dict[str, Any] = {}
+        self.priority: int = 0
 
     def __repr__(self) -> str:
         return f"<{self.tag}>"

--- a/src/typedclasses.py
+++ b/src/typedclasses.py
@@ -1,6 +1,5 @@
 import tkinter.font
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -24,3 +23,4 @@ class LineItem:
     x: int
     text: str
     font: tkinter.font.Font
+    color: str

--- a/src/url.py
+++ b/src/url.py
@@ -106,7 +106,7 @@ class URL:
                 _, url = url.split("/", 1)
                 if "/" in dir:
                     dir, _ = dir.rsplit("/", 1)
-            url: str = f"{dir}/{url}"
+            url = f"{dir}/{url}"
         if url.startswith("//"):
             return URL(f"{self.scheme}:{url}")
         else:

--- a/src/url.py
+++ b/src/url.py
@@ -5,7 +5,6 @@ from constants import PORTS
 
 
 class URL:
-
     def __init__(self, url: str) -> None:
         self.view_source: bool = False
         try:
@@ -97,3 +96,18 @@ class URL:
         content = response.read()
         s.close()
         return content
+
+    def resolve(self, url: str):
+        if "://" in url:
+            return URL(url)
+        if not url.startswith("/"):
+            dir, _ = self.path.rsplit("/", 1)
+            while url.startswith("../"):
+                _, url = url.split("/", 1)
+                if "/" in dir:
+                    dir, _ = dir.rsplit("/", 1)
+            url: str = f"{dir}/{url}"
+        if url.startswith("//"):
+            return URL(f"{self.scheme}:{url}")
+        else:
+            return URL(f"{self.scheme}://{self.host}:{str(self.port)}{url}")

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -44,19 +44,7 @@ class TestLayout:
         assert len(display_list) == 1
         word1 = display_list[0]
         assert word1.text == "JSON"
-        assert word1.font.size == 10
-        assert word1.font.weight == "bold"
-
-    def test_abbr_tag_respects_mixed_casing(self):
-        # This doesn't pass the specifications in the exercise, as it
-        # still bolds the uppercase letters in e.g. JsOn
-        display_list = self.setup("<head><abbr>JsOn 123</abbr>")
-        assert len(display_list) == 2
-        word1 = display_list[0]
-        assert word1.text == "JSON"
-        assert word1.font.weight == "bold"
-        word2 = display_list[1]
-        assert word2.font.weight == "normal"
+        assert word1.font.size == 12
 
     def test_soft_hyphen_breaks_long_line(self):
         display_list = self.setup(

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -2,11 +2,13 @@ from constants import HSTEP
 from document_layout import DocumentLayout
 from parser import HTMLParser
 from browser import paint_tree
+from css_parser import style
 
 
 class TestLayout:
     def setup(self, html: str, rtl: bool = False) -> list:
         tree = HTMLParser(html).parse()
+        style(tree, [])
         document = DocumentLayout(tree, rtl=rtl)
         document.layout()
         display_list = []

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -82,19 +82,3 @@ class TestLayout:
         assert display_list[0].text == "super­cali­fragi­listic­expi­ali­docious-"
         assert display_list[1].text == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-"
         assert display_list[2].text == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-
-    def test_pre_tag_uses_monospaced_font(self):
-        display_list = self.setup("<pre>def get_font(self):</pre>")
-        assert len(display_list) == 2
-        assert display_list[1].font.family == "Courier New"
-
-    def test_pre_tag_maintains_whitespace(self):
-        display_list = self.setup("<pre>def get_font(self):               return</pre")
-        assert len(display_list) == 2
-        assert display_list[1].text == "def get_font(self):               return"
-
-    def test_pre_tag_maintains_nested_tags(self):
-        display_list = self.setup("<pre>def get_font(self):<b>return</b></pre>")
-        assert len(display_list) == 3
-        assert display_list[2].font.weight == "bold"
-        assert display_list[2].font.family == "Courier New"


### PR DESCRIPTION
* Extend URL parser to read CSS stylesheets
* Implement `CSSParser` to parse CSS stylesheet
* Assign styles directly to `Element` and `Text` classes instead of setting globals on `BlockLayout`
* Remove `open_tag` and `close_tag` and move font properties to browser stylesheet - e.g., apply `font-weight: bold` to `b` tags