### PR TITLE
Exercise 6.2, support class selectors

### DIFF
--- a/src/block_layout.py
+++ b/src/block_layout.py
@@ -15,7 +15,7 @@ from draw import DrawRect, DrawText
 from font_cache import get_font
 from typedclasses import LineItem
 from parser import Text, Element
-from typing import Literal, Optional
+from typing import Optional
 
 
 class BlockLayout:
@@ -111,7 +111,7 @@ class BlockLayout:
             offset = self.width - (HSTEP * 2) - self.cursor_x
 
         if self.alignment == Alignment.CENTER:
-            offset = int((self.width - self.line[-1].x - SCROLLBAR_WIDTH) / 2)
+            offset = int((self.width - self.cursor_x - SCROLLBAR_WIDTH) / 2)
 
         # Add words to display_list
         for item in self.line:

--- a/src/browser.css
+++ b/src/browser.css
@@ -3,4 +3,4 @@ i { font-style: italic; }
 b { font-weight: bold; }
 small { font-size: 90%; }
 big { font-size: 110%; }
-abbr { font-size: 90%; font-weight: bold;}
+abbr { font-size: 90%; font-weight: bold; }

--- a/tests/test_css_parser.py
+++ b/tests/test_css_parser.py
@@ -1,0 +1,43 @@
+from css_parser import CSSParser, ClassSelector, DescendantSelector, TagSelector
+
+
+class TestCSSParser:
+    def test_parses_tag_selector(self):
+        rules = CSSParser("a { color: blue; }").parse()
+        assert len(rules) == 1
+        selector, body = rules[0]
+        assert isinstance(selector, TagSelector)
+        assert selector.tag == "a"
+        assert isinstance(body, dict)
+        assert body.get("color") == "blue"
+
+    def test_parses_descendant_selector(self):
+        rules = CSSParser("div a { color: blue; }").parse()
+        assert len(rules) == 1
+        selector, body = rules[0]
+        assert isinstance(selector, DescendantSelector)
+        assert isinstance(selector.ancestor, TagSelector)
+        assert selector.ancestor.tag == "div"
+        assert selector.descendant.tag == "a"
+        assert isinstance(body, dict)
+        assert body.get("color") == "blue"
+
+    def test_parses_class_selector(self):
+        rules = CSSParser(".main { color: blue; }").parse()
+        assert len(rules) == 1
+        selector, body = rules[0]
+        assert isinstance(selector, ClassSelector)
+        assert selector.cls == "main"
+        assert selector.tag is None
+        assert isinstance(body, dict)
+        assert body.get("color") == "blue"
+
+    def test_parses_class_selector_with_tag(self):
+        rules = CSSParser("p.main { color: blue; }").parse()
+        assert len(rules) == 1
+        selector, body = rules[0]
+        assert isinstance(selector, ClassSelector)
+        assert selector.cls == "main"
+        assert selector.tag == "p"
+        assert isinstance(body, dict)
+        assert body.get("color") == "blue"

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -2,7 +2,7 @@ import pytest
 from parser import HTMLParser
 
 
-class TestParser:
+class TestHTMLParser:
     @pytest.mark.parametrize(
         "input", ["test", "<body>test", "<html><body>test</body></html>"]
     )


### PR DESCRIPTION
* Add some CSS parsing tests
* Support class selectors and give them priority over tag selectors
* Detect class selectors by checking for `.` in `word()` parser